### PR TITLE
Rawkode Academy News - June 23, 2026

### DIFF
--- a/content/news/2026-06-23-crossplane-toctou-wasmtime-46-prometheus-3-13/index.mdx
+++ b/content/news/2026-06-23-crossplane-toctou-wasmtime-46-prometheus-3-13/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "Crossplane fixes a critical signing bypass, Wasmtime 46 ships, Prometheus 3.13 nears"
+description: "Crossplane backported a fix for a CVSS 9.0 signature-verification TOCTOU across four release branches, Wasmtime 46.0.0 made WASI 0.3.0 and a copying garbage collector the defaults, and Prometheus 3.13.0-rc.1 added the min_of and max_of PromQL functions."
+publishedAt: 2026-06-23
+authors:
+  - rawkode
+technologies:
+  - crossplane
+  - webassembly
+  - prometheus
+---
+
+Three releases landed on June 22 across supply-chain security, WebAssembly runtimes, and metrics.
+
+## Crossplane patches a critical signature-verification bypass across four branches
+
+The Crossplane maintainers shipped v2.3.3, v2.2.3, v2.1.7, and v1.20.10 on June 22 to fix a time-of-check-to-time-of-use flaw in package signature verification, rated critical at CVSS 9.0 ([GHSA-wfqx-gjrf-g28r](https://github.com/crossplane/crossplane/security/advisories/GHSA-wfqx-gjrf-g28r)).
+
+When signature verification is enabled and a package is installed by tag, a malicious OCI registry could serve a correctly signed image for the verification step and then serve unsigned content for installation, because Crossplane resolved the tag separately for each step. The fix resolves the tag once and pins the resulting digest for both verification and install. The flaw affects only operators who combine three conditions: signature verification enabled, tag-based rather than digest-based package installs, and registries they do not control. Versions up to and including v2.3.2 are affected; installing packages by digest mitigates it.
+
+The same release also corrects `crossplane render` namespace assignment on injected resource references and bumps the Go toolchain and `golang.org/x/net`.
+
+**Source:** [Crossplane v2.3.3](https://github.com/crossplane/crossplane/releases/tag/v2.3.3) - June 22, 2026
+
+---
+
+## Wasmtime 46.0.0 makes WASI 0.3.0 and the copying GC the defaults
+
+The Bytecode Alliance released Wasmtime 46.0.0 on June 22, enabling WASI 0.3.0 and the component model's async support by default.
+
+The release turns on the `component-model-async` Wasm feature by default alongside WASI 0.3.0, and switches the default garbage collector from deferred reference counting to a copying collector that can reclaim cycles. It adds opt-in support for the WebAssembly branch-hinting proposal via `Config::wasm_branch_hinting`, exposes component async call stacks for root-task identification, and adds a `--header` option to `wasmtime serve`. The build now requires Rust 1.94.0.
+
+For embedders, the GC default change and async-by-default component model alter runtime behavior on upgrade, not just the set of available features.
+
+**Source:** [Wasmtime v46.0.0](https://github.com/bytecodealliance/wasmtime/releases/tag/v46.0.0) - June 22, 2026
+
+---
+
+## Prometheus 3.13 release candidate adds min_of and max_of to PromQL
+
+Prometheus published 3.13.0-rc.1 on June 22, the second candidate for the 3.13 line.
+
+The candidate adds experimental `min_of(a, b)` and `max_of(a, b)` scalar functions; these are also the new names for the experimental duration-expression `min()`/`max()` functions, renamed to avoid collision with the `min` and `max` aggregation operators. It adds smoothed/anchored rate support for native histograms and a `storage.tsdb.chunk_encoding.floats` option to select float chunk encoding at runtime. On performance, the release notes report roughly 12–15% faster queries from reduced per-sample overhead during chunk population and up to 2x faster case-insensitive regex matching.
+
+As a release candidate, this is a preview rather than an upgrade target, but it shows where the 3.13 line is taking PromQL and native-histogram rate handling.
+
+**Source:** [Prometheus v3.13.0-rc.1](https://github.com/prometheus/prometheus/releases/tag/v3.13.0-rc.1) - June 22, 2026
+
+---


### PR DESCRIPTION
## Summary

Three releases on June 22 cleared the pipeline: a coordinated Crossplane security patch for a critical (CVSS 9.0) package signature-verification TOCTOU, the Wasmtime 46.0.0 major release flipping WASI 0.3.0 and a copying garbage collector to defaults, and the Prometheus 3.13.0-rc.1 candidate adding `min_of`/`max_of` PromQL functions and native-histogram rate smoothing. All three are anchored to GitHub release artifacts timestamped within the 24-hour window. Routine patch releases (Talos v1.13.5, Helm v3.21.2) and arXiv inference-serving papers were dropped for lack of standout substance or verifiability.

## Run metadata

- Run time: `2026-06-23 06:00 Europe/London`
- Coverage window: `2026-06-22 06:00 BST` to `2026-06-23 06:00 BST` (`2026-06-22T05:00Z`–`2026-06-23T05:00Z`)
- Source URLs inspected: `~46`
- Candidates longlisted: `7`
- Candidates shortlisted: `4`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Crossplane patches a critical signature-verification bypass across four branches - a malicious OCI registry could swap signed images for unsigned content during tag-based installs.
- Wasmtime 46.0.0 makes WASI 0.3.0 and the copying GC the defaults - upgrade changes runtime behavior, not just available features.
- Prometheus 3.13 release candidate adds min_of and max_of to PromQL - plus native-histogram rate smoothing and runtime float chunk encoding.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Crossplane v2.3.3/v2.2.3/v2.1.7/v1.20.10 all released 2026-06-22 | github.com/crossplane/crossplane releases.atom (ISO timestamps 2026-06-22T16:39–17:32Z) | ✅ |
| TOCTOU signature-verification bypass, CVSS 9.0, no CVE, affected ≤v2.3.2, patched v2.3.3/v2.2.3 | GHSA-wfqx-gjrf-g28r advisory page | ✅ |
| Wasmtime 46.0.0 released 2026-06-22; WASI 0.3.0 + component-model-async default; copying GC default; Rust 1.94.0 | github.com/bytecodealliance/wasmtime release-46.0.0 RELEASES.md (quoted bullets) | ✅ |
| Prometheus 3.13.0-rc.1 released 2026-06-22 | prometheus/prometheus releases.atom (2026-06-22T16:45:27Z) | ✅ |
| min_of/max_of scalar functions (renamed from experimental min()/max() duration-expr); smoothed/anchored native-histogram rate | v3.13.0-rc.1 release notes + CHANGELOG corroboration | ✅ |

## Items considered and dropped

- Talos v1.13.5 (2026-06-22) - in window but routine dependency-bump patch (kernel 6.18.36, K8s v1.36.2, containerd 2.2.5); no standout change.
- Helm v3.21.2 (2026-06-20) - outside the 24h window.
- llama.cpp builds b9755–b9763 (2026-06-22) - continuous per-merge CI builds, not newsworthy releases.
- arXiv inference-serving papers (Concordia, ASAP, LiveServe; 2026-06-22/23) - relevant topic but submission/author details not reliably verifiable via available tooling, and serving-optimization papers are heavily covered; held for human review if desired.
- CNCF blog "Telemetry that matters" (2026-06-22) - Tier 2 panel recap, opinion not news.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 7
- Segments shipped: 3
- Freshness nuance: the Crossplane advisory (GHSA-wfqx-gjrf-g28r) was *published* June 16, but the *patched releases* shipped June 22 — the segment is anchored to the in-window release artifacts, and the actionable news is the fix landing.
- Any vendor-attributed claims: Prometheus performance figures (~12–15% faster queries, up to 2x regex) are attributed to the project's own release notes; no independent benchmark exists.
- File format follows the repo's `content/news/{slug}/index.mdx` convention (authors/technologies frontmatter), not the generic spec template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bby2ue9L7KHmCKr9qyNnfJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bby2ue9L7KHmCKr9qyNnfJ)_