### PR TITLE
Rawkode Academy News - June 25, 2026

### DIFF
--- a/content/news/2026-06-25-istio-cve-gateway-api-llm-d/index.mdx
+++ b/content/news/2026-06-25-istio-cve-gateway-api-llm-d/index.mdx
@@ -1,0 +1,50 @@
+---
+title: "Istio patches 14 data-plane CVEs, Gateway API promotes TCPRoute and UDPRoute to v1, llm-d 0.8.0 adds a Slurm mode"
+description: "Istio cut a coordinated security release across three branches to fix 14 Envoy data-plane CVEs, Gateway API's v1.6 release candidate graduated its L4 routes to v1, and llm-d 0.8.0 extended distributed inference beyond Kubernetes."
+publishedAt: 2026-06-25
+authors:
+  - rawkode
+technologies:
+  - istio
+  - envoy
+  - kubernetes
+  - llm-d
+---
+
+Three primary-source releases landed in the last 24 hours across service mesh, the Kubernetes networking API, and distributed inference. Two are security- and stability-driven; one moves L4 routing toward stable.
+
+## Istio ships 1.30.2, 1.29.5, and 1.28.9 to patch 14 data-plane CVEs
+
+Istio published a coordinated patch release across its three supported branches on June 24, fixing a batch of Envoy proxy vulnerabilities tracked under [ISTIO-SECURITY-2026-005](https://istio.io/latest/news/security/istio-security-2026-005/). The advisory covers 14 CVEs in the data plane, rated up to CVSS 7.5.
+
+The highest-impact issues include an HTTP/3 QPACK header denial-of-service that drives unbounded memory growth, a PROXY-protocol TLV length mismatch that enables request smuggling, and a padding-oracle in the OAuth2 filter's AES-256-CBC cookie decryption. The advisory also fixes an ext_authz filter use-after-free crash during authorization checks and a Subject Alternative Name validation bypass using embedded NUL bytes. Fixes ship in 1.30.2, 1.29.5, and 1.28.9; earlier patch releases on each branch are affected.
+
+Because the bugs sit in the sidecar and gateway data plane, an unpatched mesh exposes every routed request to the denial-of-service and request-smuggling paths, making this a patch-now release for operators.
+
+**Source:** [Istio](https://github.com/istio/istio/releases/tag/1.30.2) - June 24, 2026
+
+---
+
+## Gateway API v1.6 release candidate promotes TCPRoute and UDPRoute to v1
+
+The Kubernetes Gateway API project cut [v1.6.0-rc.2](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0-rc.2) on June 25, graduating its two L4 route types to the standard channel. TCPRoute and UDPRoute move from experimental to v1, giving raw TCP and UDP routing the same stability guarantee as HTTPRoute.
+
+The candidate also lands a breaking change: HTTPS listeners must now configure TLS explicitly, enforced through CEL validation rather than left optional. Smaller changes raise the TLSRoute hostname limit from 16 to 1024 entries, convert HTTPRoute retry status codes to a validated set requiring at least one attempt, and remove the optional marker from ReferenceGrant's spec.
+
+This is a release candidate rather than a stable build, but implementers and platform teams should test the TLS enforcement before v1.6 ships, since HTTPS listeners that previously omitted TLS configuration will now be rejected.
+
+**Source:** [Gateway API](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0-rc.2) - June 25, 2026
+
+---
+
+## llm-d 0.8.0 graduates batch, multi-modal, and flow control, and adds a non-Kubernetes mode
+
+The llm-d distributed inference project released [v0.8.0](https://github.com/llm-d/llm-d/releases/tag/v0.8.0) on June 24, moving several router capabilities to production and extending the stack beyond Kubernetes. Multi-modal serving, the batch gateway, and flow control all graduate from incubation to production in llm-d-router.
+
+The release adds a non-Kubernetes mode aimed at reinforcement-learning and Slurm environments through a FileDiscovery plugin, multi-tier KV-cache offloading from GPU to CPU to storage, heterogeneous memory allocation, a Mooncake connector, and predicted-latency scheduling in the router. The build moves to upstream vLLM 0.23.0 images for GPU, ROCm, and CPU, retiring most of llm-d's custom-built variants, and bumps CUDA to 13.0.2.
+
+The Slurm and RL path is the notable shift: it lets the same routing and KV-offload stack run outside Kubernetes on HPC schedulers, rather than only on orchestrated clusters.
+
+**Source:** [llm-d](https://github.com/llm-d/llm-d/releases/tag/v0.8.0) - June 24, 2026
+
+---


### PR DESCRIPTION
## Summary

A three-segment daily digest for the June 24-25 publishing window. The 24 hours produced two security/stability-driven releases and one inference milestone, all primary-sourced and in-window: Istio's coordinated CVE patch wave across three branches, the Gateway API v1.6 release candidate graduating its L4 routes to v1, and llm-d 0.8.0 graduating several router capabilities to production while adding a non-Kubernetes (RL/Slurm) mode. Weaker in-window items were dropped rather than padding.

## Run metadata

- Run time: `2026-06-25 06:00 Europe/London`
- Coverage window: `2026-06-24 05:00 UTC` to `2026-06-25 05:00 UTC`
- Source URLs inspected: `~36` (GitHub release pages + API, project security bulletins, CNCF/Kubernetes blogs, arXiv cs.DC)
- Candidates longlisted: `~9`
- Candidates shortlisted: `4`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Istio 1.30.2/1.29.5/1.28.9 - coordinated security release fixing 14 Envoy data-plane CVEs; patch-now for mesh operators
- Gateway API v1.6.0-rc.2 - TCPRoute and UDPRoute promoted to v1, plus a breaking change requiring TLS on HTTPS listeners
- llm-d 0.8.0 - batch/multi-modal/flow-control graduate to production; non-Kubernetes RL/Slurm mode lets the stack run on HPC schedulers

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Istio 1.30.2/1.29.5/1.28.9 published 2026-06-24 | GitHub API `published_at` 2026-06-24T18:25–18:26Z | ✅ |
| Advisory ISTIO-SECURITY-2026-005, 14 CVEs, CVSS up to 7.5 | istio.io security bulletin istio-security-2026-005 | ✅ |
| Vulnerability classes (HTTP/3 QPACK DoS, PROXY-protocol smuggling, OAuth2 padding oracle, ext_authz UAF, SAN NUL-byte bypass) | istio.io bulletin, enumerated classes | ✅ |
| Gateway API v1.6.0-rc.2 published 2026-06-25 | GitHub API `published_at` 2026-06-25T04:51:48Z (prerelease) | ✅ |
| TCPRoute and UDPRoute promoted to v1; TLS-on-HTTPS CEL enforcement; TLSRoute hostname 16→1024 | GitHub release notes + CHANGELOG for v1.6.0-rc.2 | ✅ |
| llm-d v0.8.0 published 2026-06-24 | GitHub API `published_at` 2026-06-24T21:20:22Z | ✅ |
| Batch/multi-modal/flow-control graduate to production; non-K8s RL/Slurm mode; multi-tier KV offload; vLLM 0.19.1→0.23.0; CUDA 13.0.2 | GitHub release notes for v0.8.0 | ✅ |

## Items considered and dropped

- OpenTelemetry Collector v0.155.0 (2026-06-24T20:55Z) - in-window but appears to be routine dependency bumps; no notable component/feature change verified, fails technical-substance bar
- Kubernetes v1.37.0-alpha.2 (2026-06-25T02:40Z) - routine alpha, no highlighted feature
- Kubernetes blog "Spotlight on WG Device Management" (2026-06-24) - community working-group profile, not a technical artifact
- "CrossPool" MoE serving paper (arXiv) - relevant topic but submitted 2026-06-23, outside the 24h window
- Envoy 1.38.3/1.37.5/1.36.9/1.35.13 security releases (2026-06-23) - out of window; the in-window Istio release consumes these CVEs and is cited instead
- Prometheus v3.13.0-rc.1, Crossplane 2.3.3, Grafana 13.0.3, Talos 1.13.5, Containerd 2.3.2 - all 2026-06-22/23, outside the window

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~9 in-window artifacts across ~36 inspected URLs
- Segments shipped: 3
- Vendor-attributed claims: none; all claims trace to project primary sources (GitHub releases/API, Istio security bulletin)
- Framing concerns: Gateway API item is a release candidate, not GA, and is framed as such; Istio CVE IDs were taken verbatim from the official bulletin rather than inferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011n6wywoAP68veVPUNEr6xu

---
_Generated by [Claude Code](https://claude.ai/code/session_011n6wywoAP68veVPUNEr6xu)_