### PR TITLE
Rawkode Academy News - June 26, 2026

### DIFF
--- a/content/news/2026-06-26-cert-manager-cve-opa-1-18-tensorrt-multi-device/index.mdx
+++ b/content/news/2026-06-26-cert-manager-cve-opa-1-18-tensorrt-multi-device/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "cert-manager patches a high-severity RBAC escalation, OPA 1.18 lands, TensorRT 11 adds multi-GPU inference"
+description: "cert-manager shipped v1.20.3 and v1.19.6 to fix a CVSS 7.3 privilege-escalation in its default edit ClusterRole, OPA 1.18 added container-aware memory limits, NVIDIA promoted TensorRT multi-device inference to a supported feature, and Cloudflare detailed how it built saga rollbacks for Workflows."
+publishedAt: 2026-06-26
+authors:
+  - rawkode
+technologies:
+  - cert-manager
+  - opa
+---
+
+Four primary-source items cleared the freshness gate in the last 24 hours: a high-severity cert-manager security patch, a feature release of OPA, TensorRT's promotion of multi-GPU inference to a supported runtime feature, and a Cloudflare engineering write-up on durable saga rollbacks. It was an otherwise quiet window, so this is four, not six.
+
+## cert-manager patches a high-severity privilege-escalation in its default edit role
+
+cert-manager published [v1.20.3 and v1.19.6](https://github.com/cert-manager/cert-manager/releases/tag/v1.20.3) on June 25 to fix a CVSS 7.3 issue (advisory GHSA-8rvj-mm4h-c258, no CVE assigned yet) in the default `cert-manager-edit` aggregated ClusterRole. Versions 1.18.0 through 1.20.2 are affected.
+
+The role granted namespace users `create` on ACME `Challenge` resources and `create`, `patch`, and `update` on `Order` resources, both internal to cert-manager's issuance flow. A tenant with that access could create a `Challenge` that references a `ClusterIssuer` while supplying an attacker-controlled DNS solver configuration. cert-manager derives the secret namespace and ambient-credential policy from the `ClusterIssuer` but applies the user-supplied solver, so the request bypasses the issuer's `dnsZones` and `dnsNames` selectors. With the acme-dns provider, the attacker's solver host receives the `X-Api-User` and `X-Api-Key` headers that cert-manager loads from the issuer's namespace, disclosing platform-owned DNS credentials.
+
+The patch removes `create` on Challenges and `create`/`patch`/`update` on Orders from `cert-manager-edit`; any tooling that created those resources directly must now be granted the permissions explicitly. The release also bumps Go to 1.26.4. Multi-tenant clusters that rely on the default aggregated roles should upgrade and audit automation that touches Challenge or Order objects.
+
+**Source:** [cert-manager v1.20.3](https://github.com/cert-manager/cert-manager/releases/tag/v1.20.3) - June 25, 2026
+
+---
+
+## OPA 1.18 adds container-aware memory limits and a breaking User-Agent change
+
+Open Policy Agent released [v1.18.0](https://github.com/open-policy-agent/opa/releases/tag/v1.18.0) on June 25. It restores automatic `GOMAXPROCS` and adds automatic `GOMEMLIMIT`, so OPA reads cgroup CPU and memory limits without manual tuning — relevant for sidecar and admission-controller deployments that previously risked OOMKills under static Go defaults.
+
+The release also carries a breaking change: the outbound `User-Agent` header changes from `Open Policy Agent/<version>` to `Open-Policy-Agent/<version>` to conform to RFC 9110. Any exact-match filtering or allowlisting on the old string will break. Beyond that, it ships `opa fmt` correctness fixes for multiline iterables and `with`-clause preservation, `opa test --coverage` improvements including range support and rule-head tracking, and bundle determinism fixes for modules with overlapping Rego versions.
+
+**Source:** [OPA v1.18.0](https://github.com/open-policy-agent/opa/releases/tag/v1.18.0) - June 25, 2026
+
+---
+
+## TensorRT 11.0 promotes multi-device inference to a supported feature
+
+NVIDIA published a [June 25 technical post](https://developer.nvidia.com/blog/scaling-ai-inference-across-multiple-gpus-using-nvidia-tensorrt-with-multi-device-inference-support) detailing native multi-GPU inference in TensorRT 11.0. Multi-device inference, a preview in 10.16 that required the `kMULTIDEVICE_RUNTIME_10_16` builder flag, is fully supported in 11.0.0 with the flag removed.
+
+The runtime executes distributed collectives through NCCL, covering the full set — AllReduce, Broadcast, Reduce, AllGather, ReduceScatter, AllToAll, Gather, and Scatter — with AllToAll, Gather, and Scatter newly added to the `IDistCollectiveLayer`. TensorRT now auto-discovers the NCCL library, checking for `libnccl.so.2` before falling back to `libnccl.so` via `LD_LIBRARY_PATH`. NVIDIA reports benchmarks on 8 GPUs using Cosmos 3 for video and FLUX.1-dev for image generation, in which DeepSpeed Ulysses delivered the lowest latency at long context lengths and Ring Attention scaled effectively to 4 GPUs.
+
+This moves sequence- and context-parallel inference into the TensorRT runtime itself, rather than requiring an external serving layer to shard a model across devices.
+
+**Source:** [NVIDIA Technical Blog](https://developer.nvidia.com/blog/scaling-ai-inference-across-multiple-gpus-using-nvidia-tensorrt-with-multi-device-inference-support) - June 25, 2026
+
+---
+
+## Cloudflare details how it built saga rollbacks for Workflows
+
+Cloudflare published a [June 25 engineering write-up](https://blog.cloudflare.com/rollbacks-for-workflows/) on the saga-style rollback support in its Workflows durable-execution engine. Compensation is declared inline on each step — `step.do(name, fn, { rollback: compensationFn })` — and on failure the handlers run in reverse step-start order.
+
+The design leans on persisted durable step history rather than an in-memory `catch` block. Workflows records which steps completed and whether a rollback was registered, then invokes the stored handler references (stubs, in Workers RPC terms), rebuilding them in replay mode during engine restarts without re-running completed forward steps. Compensations inherit the same retries, timeouts, lifecycle events, and recorded outcomes as forward steps, and each handler receives the triggering error along with the step's context and output. The result gives the saga pattern the same execution guarantees as the forward path, which matters for multi-step provisioning or payment flows that must unwind cleanly after a partial failure.
+
+**Source:** [Cloudflare Blog](https://blog.cloudflare.com/rollbacks-for-workflows/) - June 25, 2026
+
+---


### PR DESCRIPTION
## Summary

A four-segment daily digest covering the June 25-26 publishing window. It was a quiet 24 hours, so this ships only what passed the freshness gate as fresh, primary-sourced, in-scope material: a high-severity cert-manager security patch, a feature release of OPA, NVIDIA promoting TensorRT multi-device inference to a supported runtime feature, and a Cloudflare engineering deep-dive on durable saga rollbacks. Two CNCF OSS items and two vendor engineering write-ups with concrete technical substance — not a vendor product roundup. No padding.

## Run metadata

- Run time: `2026-06-26 06:00 Europe/London`
- Coverage window: `2026-06-25 05:00 UTC` to `2026-06-26 05:00 UTC`
- Source URLs inspected: `~45` (release atom feeds across CNCF/infra/AI projects, plus CNCF announcements, Kubernetes blog, Cloudflare blog, NVIDIA technical blog, and arXiv cs.DC)
- Candidates longlisted: `11` in-window artifacts
- Candidates shortlisted: `6`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- cert-manager patches a high-severity privilege-escalation in its default edit role - CVSS 7.3 RBAC issue lets a tenant exfiltrate platform DNS credentials via attacker-controlled ACME solvers.
- OPA 1.18 adds container-aware memory limits and a breaking User-Agent change - automatic GOMEMLIMIT prevents OOMKills in memory-limited deployments; RFC 9110 header change can break exact-match filters.
- TensorRT 11.0 promotes multi-device inference to a supported feature - native multi-GPU inference via the full NCCL collective set, moving sequence/context-parallel serving into the runtime.
- Cloudflare details how it built saga rollbacks for Workflows - durable compensation gives the saga pattern the same retry/timeout/replay guarantees as the forward path.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| cert-manager v1.20.3 + v1.19.6 published June 25; fix GHSA-8rvj-mm4h-c258, CVSS 7.3, no CVE assigned; affected 1.18.0–1.20.2 | [GHSA-8rvj-mm4h-c258](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258) + [v1.20.3 release](https://github.com/cert-manager/cert-manager/releases/tag/v1.20.3) | ✅ |
| Mechanism: attacker-controlled `Challenge.spec.solver` with ClusterIssuer credentials leaks acme-dns `X-Api-User`/`X-Api-Key`; patch removes Challenge `create` and Order `create/patch/update` from `cert-manager-edit`; Go bumped to 1.26.4 | Advisory body + release notes | ✅ |
| OPA v1.18.0 published June 25; restores automatic GOMAXPROCS, adds automatic GOMEMLIMIT; breaking User-Agent `Open Policy Agent/` → `Open-Policy-Agent/` per RFC 9110 | [OPA v1.18.0 release](https://github.com/open-policy-agent/opa/releases/tag/v1.18.0) | ✅ |
| TensorRT 11.0 makes multi-device inference fully supported (preview/flag in 10.16 removed); full NCCL collective set; AllToAll/Gather/Scatter added to IDistCollectiveLayer; auto NCCL discovery; 8-GPU benchmarks on Cosmos 3 + FLUX.1-dev (NVIDIA-reported) | [NVIDIA Technical Blog, June 25](``https://developer.nvidia.com/blog/scaling-ai-inference-across-multiple-gpus-using-nvidia-tensorrt-with-multi-device-inference-support``) | ✅ |
| Cloudflare Workflows saga rollbacks: `step.do(name, fn, { rollback })`, reverse step-start order, persisted step history vs in-memory catch, stub rebuild in replay mode | [Cloudflare Blog, June 25](https://blog.cloudflare.com/rollbacks-for-workflows/) | ✅ |

## Items considered and dropped

- SGLang v0.5.14 (June 26 00:51 UTC) - in window, but no published release notes / empty body; a cherry-pick patch on v0.5.13 with no verifiable technical substance.
- vLLM v0.24.0rc2 (June 25) - minor cherry-pick release candidate ("Fix P/D with DP Supervisor"); v0.24.0 line not yet released.
- k3s v1.36.2+k3s1 stable wave (June 26) - repackages the June 9 upstream Kubernetes patch releases; routine downstream packaging, no fresh substance.
- Gateway API v1.6.0-rc.2 (June 25 04:51 UTC) - notable breaking change (TLS now required for HTTPS listeners) but timestamped ~9 min before the window and pre-release.
- Thanos v0.42.0-rc.1 (June 25) - in-window but a release candidate, preview-only.
- Kubernetes v1.37.0-alpha.2 (June 25 02:40 UTC) - alpha and before the window start.
- arXiv "Energy Efficient Scheduling of AI/ML Workloads on Multi-Instance GPUs with Dynamic Repartitioning" - appears as an IEEE conference publication; the arXiv posting resurfaces prior work, so freshness could not be cleanly established.
- Istio 1.30.2/1.29.5/1.28.9, Dapr 1.18.x, OTel Collector v1.61, Wasmtime v46.0.1, Crossplane v2.3.3, Prometheus 3.13.0-rc.1 - all June 22-24, outside the window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~11 in-window; 6 shortlisted; 4 shipped
- Framing note: the Cloudflare rollback feature became available earlier in June (a June 5 changelog entry); the June 25 post is the engineering build write-up. The segment is framed as a deep-dive on how it was built, not a launch.
- Vendor-attributed claims: the TensorRT 8-GPU latency results are NVIDIA-reported benchmarks (no independent corroboration found) and are attributed as such in the segment. No vendor press releases were republished.
- Segments span security, policy/runtime ops, AI/HPC inference, and platform engineering — no single-vendor roundup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C782Vj657nQ1anKD4SXb4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01C782Vj657nQ1anKD4SXb4c)_