### PR TITLE
Rawkode Academy News - June 27, 2026

### DIFF
--- a/content/news/2026-06-27-sglang-talos-kueue-volcano/index.mdx
+++ b/content/news/2026-06-27-sglang-talos-kueue-volcano/index.mdx
@@ -1,0 +1,58 @@
+---
+title: "SGLang 0.5.14 lands DeepSeek-V4 kernels, Talos 1.14 alpha mounts /var noexec, Kueue and Volcano patch their schedulers"
+description: "SGLang cut v0.5.14 with DeepSeek-V4 serving optimizations and Blackwell load-balancing, Talos v1.14.0-alpha.2 hardened the node filesystem and added encrypted DNS, and Kueue and Volcano shipped scheduler bug-fix patches."
+publishedAt: 2026-06-27
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - volcano
+---
+
+Four primary-source releases landed in the last 24 hours across inference serving, the node OS, and batch scheduling. It was a release-heavy but otherwise quiet window, so this is a tight digest rather than a padded one.
+
+## SGLang 0.5.14 adds DeepSeek-V4 kernels and Blackwell load-balancing for expert parallelism
+
+The SGLang project published [v0.5.14](https://github.com/sgl-project/sglang/releases/tag/v0.5.14) on June 26, its first tagged release since v0.5.13 on June 13, focused on DeepSeek-V4 serving and new model support.
+
+The release adds two dispatch-time load-balancing methods, Waterfill and LPLB, for DeepEP expert parallelism on DeepSeek-V3/R1 and DeepSeek-V4, and a new KDA CuteDSL prefill kernel for Kimi-Linear that the project reports as 1.08–1.52x faster than the Triton path on Blackwell (SM100). For DeepSeek-V4 on NVIDIA GB300, SGLang reports 5x higher throughput at the same interactivity. On the memory side, an int8 checkpoint pool for the Mamba radix cache grows prefix-cache capacity, and deduplicating the speculative-decoding intermediate conv-window cache halves its footprint. Breakable CUDA graph execution now also runs on AMD via ROCm/HIP, and day-0 support arrives for GLM-5.2, LiquidAI LFM2.5, Kimi-K2.7-Code, and others. The bundled sgl-kernel moves to 0.4.4 and the minimum Ray version rises to 2.55.1.
+
+The GB300 and Blackwell numbers are project-reported on its own configurations, not independently benchmarked.
+
+**Source:** [SGLang v0.5.14 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.14) - June 26, 2026
+
+---
+
+## Talos 1.14.0-alpha.2 mounts /var noexec and adds encrypted DNS resolution
+
+Sidero Labs published [Talos v1.14.0-alpha.2](https://github.com/siderolabs/talos/releases/tag/v1.14.0-alpha.2) on June 26, an alpha preview of the 1.14 line carrying node-hardening changes and an etcd version bump.
+
+The EPHEMERAL `/var` partition now mounts `noexec` alongside the existing `nosuid` and `nodev`, blocking binary execution from `/var`; workloads that execute binaries from there, such as Longhorn, break unless operators apply a `VolumeConfig` patch first. A new `ResolverConfig` document adds DNS over TLS and DNS over HTTPS with per-nameserver protocol selection, and NRI for the CRI containerd instance is now enabled by default without a machine-config patch. The release raises the default etcd to a 3.7.0 release candidate and moves etcd's HTTP endpoints to port 2383, and `talosctl apply-config` drops `--mode=reboot`, applying configuration without a reboot by default. The node image ships Linux 6.18.36, Kubernetes 1.36.2, containerd 2.3.2, runc 1.5.0-rc.3, CoreDNS 1.14.2, and Go 1.26.4.
+
+This is an alpha rather than an upgrade target, but the `noexec` change and its Longhorn caveat are worth testing before 1.14 reaches stable.
+
+**Source:** [Talos v1.14.0-alpha.2 release](https://github.com/siderolabs/talos/releases/tag/v1.14.0-alpha.2) - June 26, 2026
+
+---
+
+## Kueue 0.18.2 fixes DRA quota admission and a LocalQueue namespace leak
+
+Kueue released [v0.18.2](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.2), with a v0.17.6 backport, on June 26, a patch spanning Dynamic Resource Allocation, MultiKueue, and namespace isolation.
+
+The release fixes a bug where workloads carrying DRA device constraints or configurations were rejected as unsupported instead of being admitted for quota processing, and closes a LocalQueue information leak where queues sharing a name across namespaces were not properly isolated. Three MultiKueue fixes land alongside: creating a Job on a manager cluster no longer deletes a pre-existing worker-cluster Job with the same NamespacedName, stale Job status is no longer retained when worker Jobs settle quickly, and scheduling-gated `PodScheduled` conditions are preserved on manager Pods to avoid spurious Cluster Autoscaler scale-ups. Operators upgrading should note that the KueuePopulator Helm chart now removes its resources on uninstall, so previously leaked ConfigMap and RBAC objects must be deleted manually first.
+
+**Source:** [Kueue v0.18.2 release](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.2) - June 26, 2026
+
+---
+
+## Volcano 1.14.3 patches GPU sharing and topology-aware scheduling
+
+Volcano shipped [v1.14.3](https://github.com/volcano-sh/volcano/releases/tag/v1.14.3) on June 27, a patch release of the batch scheduler with ten bug fixes.
+
+The release fixes HAMi vGPU scheduling failures in medium and large clusters, corrects network-topology-aware scheduling in soft mode for jobs and subjobs, and switches scalar in-queue resource accounting to milli-units. It also checks Ascend vNPU health using allocatable resources, clears device-related annotations when releasing pods, caps unbounded growth of `job.Status.Conditions`, and reprieves higher-priority pods first during preemption.
+
+For teams running shared-GPU batch workloads on Volcano, the HAMi vGPU and topology-aware fixes are the reason to take the patch.
+
+**Source:** [Volcano v1.14.3 release](https://github.com/volcano-sh/volcano/releases/tag/v1.14.3) - June 27, 2026
+
+---


### PR DESCRIPTION
## Summary

A quiet but release-heavy 24-hour window. Four primary-source releases made the cut across inference serving (SGLang 0.5.14), the node OS (Talos 1.14.0-alpha.2), and batch scheduling (Kueue 0.18.2 and Volcano 1.14.3). Each item is a tagged GitHub release published within the trailing 24 hours, and every claim traces to the release notes in that primary source. vLLM v0.24.0 was tagged in the same window but is dropped below because its release notes would not render from any primary source, so its contents could not be verified.

## Run metadata

- Run time: `2026-06-27 06:16 Europe/London`
- Coverage window: `2026-06-26 05:16 UTC` to `2026-06-27 05:16 UTC`
- Source URLs inspected: `~34`
- Candidates longlisted: `8`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- SGLang 0.5.14 adds DeepSeek-V4 kernels and Blackwell load-balancing — new expert-parallel dispatch methods and project-reported throughput gains for DeepSeek-V4 serving.
- Talos 1.14.0-alpha.2 mounts /var noexec and adds encrypted DNS — node-hardening that breaks binary-from-/var workloads like Longhorn without a VolumeConfig patch.
- Kueue 0.18.2 fixes DRA quota admission and a LocalQueue namespace leak — DRA workloads were wrongly rejected, and same-named LocalQueues leaked across namespaces.
- Volcano 1.14.3 patches GPU sharing and topology-aware scheduling — fixes HAMi vGPU scheduling failures at cluster scale and soft-mode topology placement.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| SGLang v0.5.14 published 2026-06-26 (stable, first tag since v0.5.13 on 06-13) | github.com/sgl-project/sglang releases.atom (entry v0.5.14) | ✅ |
| Waterfill + LPLB load-balancing for DeepEP expert parallelism; KDA CuteDSL prefill kernel reported 1.08–1.52x vs Triton on Blackwell SM100; 5x throughput at same interactivity on GB300 (project-reported) | SGLang v0.5.14 release notes — Highlights | ✅ (attributed) |
| Talos v1.14.0-alpha.2 published 2026-06-26; /var mounts noexec; DoT/DoH ResolverConfig; NRI default; etcd default to 3.7.0-rc, port 2383; apply-config drops --mode=reboot | github.com/siderolabs/talos v1.14.0-alpha.2 release notes | ✅ |
| Talos component versions: Linux 6.18.36, Kubernetes 1.36.2, containerd 2.3.2, runc 1.5.0-rc.3, CoreDNS 1.14.2, Go 1.26.4 | Talos v1.14.0-alpha.2 release notes — component versions | ✅ |
| Kueue v0.18.2 (+ v0.17.6 backport) published 2026-06-26; DRA device-constraint admission fix; LocalQueue cross-namespace isolation fix; three MultiKueue fixes; KueuePopulator uninstall cleanup | github.com/kubernetes-sigs/kueue v0.18.2 release notes | ✅ |
| Volcano v1.14.3 published 2026-06-27; HAMi vGPU at-scale fix (#5434), network-topology soft mode (#5513), milli-unit scalar accounting (#5503), Ascend vNPU health (#5437) | github.com/volcano-sh/volcano v1.14.3 release notes — What's Changed | ✅ |

## Items considered and dropped

- vLLM v0.24.0 (tagged 2026-06-26 23:33 UTC, stable) — release notes failed to render from the GitHub tag page, atom feed, and API (403); contents could not be verified against a primary source, so it was cut per the no-invention rule. Worth a human glance: a stable v0.24.0 did ship in-window.
- Backstage v1.52.1 (2026-06-26) — patch release; routine bug fixes, below the substance bar.
- Kubernetes blog "Open source maintainership in the age of AI" (2026-06-26) — opinion/commentary, not news; no technical artifact.
- Dragonfly v2.5.0 (2026-06-25) — substantive but published just outside the 24-hour window.
- Istio 1.30.2/1.29.5/1.28.9 (06-24), Crossplane 2.3.3 (06-22), cert-manager 1.20.3 (06-25), Helm 3.21.2 (06-20), Grafana 13.1.0 (06-23), Envoy 1.38.3 (06-24), Gateway API 1.6.0-rc.2 (06-25) — all outside the window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 8 fresh, ~34 source URLs inspected
- Segments shipped: 4
- Any unresolved framing concerns: Talos 1.14.0-alpha.2 is an alpha preview, framed explicitly as not an upgrade target. Volcano 1.14.3 is the marginal item (a pure patch) but earns inclusion on the HAMi vGPU at-scale fix for the shared-GPU audience.
- Any vendor-attributed claims: SGLang's GB300 (5x) and Blackwell SM100 (1.08–1.52x) figures are project-reported on its own configurations and explicitly attributed; no independent benchmark exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zw29FJpo4KLCeNZPXvS3o

---
_Generated by [Claude Code](https://claude.ai/code/session_014Zw29FJpo4KLCeNZPXvS3o)_