### PR TITLE
Rawkode Academy News - June 30, 2026

### DIFF
--- a/content/news/2026-06-30-gateway-api-1-6-vllm-ray-triton/index.mdx
+++ b/content/news/2026-06-30-gateway-api-1-6-vllm-ray-triton/index.mdx
@@ -1,0 +1,68 @@
+---
+title: "Gateway API 1.6 sends TCPRoute and UDPRoute to GA, vLLM 0.24, Ray 2.56, Triton 2.70"
+description: "Gateway API v1.6.0 graduates TCPRoute and UDPRoute to GA, etcd-operator joins Cozystack with a rewritten v1alpha2 API, and vLLM, Ray, and Triton all cut releases in the same 24-hour window."
+publishedAt: 2026-06-30
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - etcd
+  - vllm
+  - ray
+---
+
+A busy 24 hours across networking, control-plane tooling, and AI inference. Five primary-source releases landed, all verified against their changelogs and release notes.
+
+## Gateway API 1.6.0 graduates TCPRoute and UDPRoute to GA
+
+The Gateway API project published [v1.6.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0) on June 29, graduating both TCPRoute and UDPRoute to GA. The release notes recommend the `v1` API version for both and deprecate `v1alpha2`, which is slated for removal in a future release.
+
+The release adds a `GATEWAY-UDP` conformance profile with UDP and TCP echo-server test support, so L4 routing for non-HTTP traffic now has a conformance-tested API surface rather than an experimental one. It also tightens HTTPRoute retry validation — `retry.codes` must be unique and `retry.attempts` must be at least 1 — raises the Certificate Authority reference limit from 8 to 16, and fixes IPv6 cluster support and a ValidatingAdmissionPolicy issue that blocked installing the experimental CRDs.
+
+For platform teams exposing TCP and UDP workloads through Gateway API, the stable `v1` types remove the "still alpha" caveat that has kept L4 routing out of production manifests.
+
+**Source:** [Gateway API v1.6.0 release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0) - June 29, 2026
+
+---
+
+## etcd-operator joins Cozystack with a rewritten v1alpha2 API
+
+The [etcd-operator project moved under Cozystack](https://www.cncf.io/blog/2026/06/29/etcd-operator-joins-cozystack-with-a-new-v1alpha2-api/) and published a rewritten `v1alpha2` API on June 29. The API group changes from `etcd.aenix.io/v1alpha1` to `etcd-operator.cozystack.io/v1alpha2`, and the operator no longer manages clusters through a StatefulSet.
+
+Instead, each member is a discrete `EtcdMember` resource, and the operator drives etcd's native membership operations — `MemberAdd`, `MemberPromote`, and `MemberRemove` — directly. That enables learner-mode joins, graceful removal that preserves quorum, and pause/resume that keeps member identity intact. The rewrite also adds tmpfs-backed storage with operator-driven recreation and moves validation to API-server-side CEL, dropping the admission webhook and its certificate dependency. An in-place migration path from the legacy operator is included. Ænix maintainer Timofei Larkin implemented the rewrite; the project stays Apache 2.0.
+
+Managing membership through etcd's own API rather than StatefulSet ordinals gives the operator first-class control over the operations that actually break etcd clusters: adding, promoting, and removing voting members without losing quorum.
+
+**Source:** [CNCF blog](https://www.cncf.io/blog/2026/06/29/etcd-operator-joins-cozystack-with-a-new-v1alpha2-api/) - June 29, 2026
+
+---
+
+## vLLM 0.24.0 makes Model Runner V2 default to quantized models
+
+vLLM cut [v0.24.0](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) on June 30, a release of 571 commits from 256 contributors. Model Runner V2 now supports quantized models by default and enables GraniteMoE by default, continuing the migration of MoE models onto the newer runner path.
+
+The release adds new model families including MiniMax-M3 and a diffusion-LLM path via DiffusionGemma, a streaming parser that unifies tool-call and reasoning output across models, and broader hardware coverage spanning NVIDIA SM90/SM100 paths, AMD ROCm on Torch 2.11, Intel XPU, and TPU. A new `device_ids` argument replaces vLLM's internal manipulation of `CUDA_VISIBLE_DEVICES`. Security fixes cover an audio decompression-bomb mitigation, regex-compilation timeout guards, and a remote DoS in speculative decoding, with Starlette bumped to 1.0.1 or later. ERNIE, Xverse, Dots1, Bamba, and Mono-InternVL are removed, and Transformers v4 and first-generation Qwen/QwenVL are deprecated.
+
+**Source:** [vLLM v0.24.0 release](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) - June 30, 2026
+
+---
+
+## Ray 2.56.0 is the last release before 2.57 enforces new dependency floors
+
+[Ray 2.56.0](https://github.com/ray-project/ray/releases/tag/ray-2.56.0) shipped on June 29 and is the final release to support its older core dependencies. Version 2.57.0 will enforce minimum versions including numpy 2.1, pandas 2.2.3, pyarrow 18.0.0, pydantic 2.9, protobuf 5.26, grpcio 1.66, and scipy 1.14.1, so teams pinning older versions should plan upgrades before moving to 2.57.
+
+On features, the release re-architects Ray Serve LLM by decoupling request handling from the token-streaming response path, and adds a `ConsistentHashRouter` for session-sticky routing and a `CapacityQueueRouter` for supply-constrained workloads. Ray Core gains GPU-domain-aware placement groups that pack bundles onto nodes sharing a `ray.io/gpu-domain` label, plus support for Kubernetes in-place pod resizing. Ray Data adds `batch_size='auto'` for `map_batches` and support for multiple datasets per cluster.
+
+**Source:** [Ray 2.56.0 release](https://github.com/ray-project/ray/releases/tag/ray-2.56.0) - June 29, 2026
+
+---
+
+## Triton Inference Server 2.70.0 drops the Windows build and adds multi-GPU TensorRT
+
+NVIDIA released [Triton Inference Server 2.70.0](https://github.com/triton-inference-server/server/releases/tag/v2.70.0) (NGC container 26.06) on June 29, removing the Windows server build from the core build and documentation. The Python client now requires `ml_dtypes.bfloat16` arrays instead of casting from `np.float32`, a breaking change for clients sending BF16 tensors.
+
+The TensorRT backend gains multi-GPU (multi-device) inference, and the PyTorch backend enables dynamic batching for PyTorch 2. Other changes include a request body size limit on the OpenAI-compatible frontend, path-traversal hardening in model-environment unpacking, and a fix for server crashes when loading models from S3 after idle-connection timeouts. The bundled TensorRT-LLM backend is 1.2.1. Note that vLLM tensor parallelism greater than 1 still requires the Ray distributed executor backend in explicit model-control mode.
+
+**Source:** [Triton Inference Server 2.70.0 release](https://github.com/triton-inference-server/server/releases/tag/v2.70.0) - June 29, 2026
+
+---

--- a/content/news/2026-06-30-gateway-api-1-6-vllm-ray-triton/index.mdx
+++ b/content/news/2026-06-30-gateway-api-1-6-vllm-ray-triton/index.mdx
@@ -7,8 +7,6 @@ authors:
 technologies:
   - kubernetes
   - etcd
-  - vllm
-  - ray
 ---
 
 A busy 24 hours across networking, control-plane tooling, and AI inference. Five primary-source releases landed, all verified against their changelogs and release notes.


### PR DESCRIPTION
## Summary

A five-segment daily digest for 2026-06-30, covering a busy 24 hours of primary-source releases across networking, control-plane tooling, and AI inference. Each item is a Tier 1 source (GitHub release tag or CNCF blog) with a timestamp verified inside the coverage window, and every factual claim was checked against the release notes / changelog. The mix is deliberately balanced: two cloud-native infrastructure items (Gateway API, etcd-operator) and three AI serving/compute items (vLLM, Ray, Triton), all distinct layers of the stack.

## Run metadata

- Run time: `2026-06-30 06:00 Europe/London`
- Coverage window: `2026-06-29 05:00 UTC` to `2026-06-30 05:00 UTC`
- Source URLs inspected: `~32`
- Candidates longlisted: `11`
- Candidates shortlisted: `7`
- Segments shipped: `5`
- Time horizon: last 24 hours only

## Segments

- Gateway API 1.6.0 graduates TCPRoute and UDPRoute to GA - stable v1 L4 routing for non-HTTP traffic, v1alpha2 deprecated
- etcd-operator joins Cozystack with a rewritten v1alpha2 API - drives etcd's native Membership API instead of StatefulSets
- vLLM 0.24.0 makes Model Runner V2 default to quantized models - plus new model families, broader hardware backends, security fixes
- Ray 2.56.0 is the last release before 2.57 enforces new dependency floors - numpy 2.1 / pyarrow 18 / pydantic 2.9 etc. become hard minimums
- Triton Inference Server 2.70.0 drops the Windows build and adds multi-GPU TensorRT - breaking client BF16 change, PyTorch 2 dynamic batching

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| TCPRoute and UDPRoute graduated to GA, v1 recommended, v1alpha2 deprecated | [Gateway API v1.6.0 release notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0) (graduation section, quoted wording confirmed on two reads) | ✅ |
| GATEWAY-UDP conformance profile, retry validation (unique codes, attempts ≥1), CA refs 8→16 | [Gateway API v1.6.0 release notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0) | ✅ |
| etcd-operator moved to Cozystack; group `etcd.aenix.io/v1alpha1` → `etcd-operator.cozystack.io/v1alpha2`; per-member EtcdMember; drives MemberAdd/Promote/Remove; CEL validation drops webhook; Timofei Larkin rewrite | [CNCF blog, 2026-06-29](https://www.cncf.io/blog/2026/06/29/etcd-operator-joins-cozystack-with-a-new-v1alpha2-api/) | ✅ |
| vLLM 0.24.0: 571 commits / 256 contributors; MRv2 quantized + GraniteMoE by default; device_ids replaces internal CUDA_VISIBLE_DEVICES; security fixes; removals (ERNIE/Xverse/Dots1/Bamba/Mono-InternVL) | [vLLM v0.24.0 release notes](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) (Highlights, confirmed on two reads) | ✅ |
| Ray 2.56.0 last release before 2.57 enforces numpy 2.1 / pandas 2.2.3 / pyarrow 18 / pydantic 2.9 / protobuf 5.26 / grpcio 1.66 / scipy 1.14.1; Serve LLM re-arch; gpu-domain placement groups; IPPR | [Ray 2.56.0 release notes](https://github.com/ray-project/ray/releases/tag/ray-2.56.0) | ✅ |
| Triton 2.70.0 (NGC 26.06): Windows build dropped; TensorRT multi-GPU; PyTorch 2 dynamic batching; client requires ml_dtypes.bfloat16; S3 idle-timeout crash fix; TensorRT-LLM backend 1.2.1 | [Triton 2.70.0 release notes](https://github.com/triton-inference-server/server/releases/tag/v2.70.0) | ✅ |

## Items considered and dropped

- NATS Server v2.14.3 / v2.12.12 (2026-06-29) - in-window and substantive, but a bug-fix/maintenance patch wave with no headline feature; held back to keep the digest tight
- Karmada v1.18.1 / v1.17.4 / v1.16.7 + v1.19.0-alpha.1 (2026-06-30) - patch wave plus an alpha; no single newsworthy change for a general audience
- TensorRT-LLM v1.3.0rc20 (2026-06-30) - release candidate / nightly-style tag, not a stable target
- CNCF blog "OTel and mesh-derived metrics: A 2026 reference" (2026-06-29) - reads as a reference/how-to article, not news
- llama.cpp builds b9837–b9843 and a wasmtime `dev` tag (2026-06-29/30) - rolling per-commit tags, not editorial releases

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 11
- Segments shipped: 5
- Any unresolved framing concerns: none. Note that all dates were verified via GitHub release Atom-feed ISO timestamps and the CNCF blog publish date; WebFetch's prose summaries occasionally mis-guessed the year (saying 2024/2025), but the machine-readable feed timestamps are all 2026 and were used as the source of truth.
- Any vendor-attributed claims: vLLM's small per-model performance percentages (e.g. DeepSeek-V4 TTFT/throughput deltas) were intentionally left out of the prose; only structural, verifiable facts were kept. Triton is an NVIDIA project but the segment reports concrete build/API changes, not positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1f5gfsLUwaUrGXoQzR1Vv

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1f5gfsLUwaUrGXoQzR1Vv)_