### PR TITLE
Rawkode Academy News - July 1, 2026

### DIFF
--- a/content/news/2026-07-01-flux-2-9-kepler-rewrite-wasmcloud-wasip3/index.mdx
+++ b/content/news/2026-07-01-flux-2-9-kepler-rewrite-wasmcloud-wasip3/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "Flux 2.9 ships a CLI plugin system, Kepler drops eBPF for /proc, wasmCloud turns on WASI Preview 3"
+description: "Flux v2.9.0 adds a CLI plugin system, post-quantum SOPS decryption, and Workload Identity auth; Kepler rewrites its power-monitoring data path off eBPF onto read-only /proc and /sys; and wasmCloud v2.5.0 enables WASI Preview 3 by default on Wasmtime 46."
+publishedAt: 2026-07-01
+authors:
+  - rawkode
+technologies:
+  - fluxcd
+  - kepler
+  - wasmcloud
+---
+
+Three primary-source releases and rewrites landed inside the last 24 hours across GitOps, power monitoring, and WebAssembly runtimes. It was a thin window otherwise, so this is a short, verified digest rather than a padded one.
+
+## Flux 2.9.0 adds a CLI plugin system and post-quantum SOPS decryption
+
+The Flux project published [v2.9.0](https://github.com/fluxcd/flux2/releases/tag/v2.9.0) on June 30 as a feature release, moving the core controllers onto the v1.9 line (source-controller v1.9.1, kustomize-controller v1.9.1, notification-controller v1.9.1, helm-controller v1.6.1, source-watcher v2.2.1).
+
+The headline addition is a CLI plugin system: `flux plugin install` pulls community extensions with digest pinning, and the release ships two built-in plugins, Mirror and Schema. SOPS decryption in Kustomization now supports the Age post-quantum cipher. Workload Identity support expands to OpenBao and Vault auth in Kustomization and to AWS CodeCommit in GitRepository, shifting those paths off static credentials. HelmRelease gains post-render strategies with chart-hook support and a `--set-literal`-style literal mode, and OCIRepository can pin custom Sigstore trusted roots for keyless verification in air-gapped clusters.
+
+This release removes the `image.toolkit.fluxcd.io/v1beta2` and `notification.toolkit.fluxcd.io/v1beta2` API versions from the CRDs, so operators must follow the documented upgrade procedure before bumping.
+
+**Source:** [Flux v2.9.0 release](https://github.com/fluxcd/flux2/releases/tag/v2.9.0) - June 30, 2026
+
+---
+
+## Kepler replaces eBPF with read-only /proc and /sys for power monitoring
+
+In a [June 30 CNCF post](https://www.cncf.io/blog/2026/06/30/kepler-re-architected-improved-power-accuracy-and-a-community-call-to-action/), Niki Manoledaki (Grafana Labs) and Sunyanan Choochotkaew (IBM) describe a re-architecture of Kepler's power-monitoring data path and a call for community validation.
+
+The previous design used eBPF to capture utilization signals, which required `CAP_BPF` and `CAP_SYSADMIN` and missed short-lived processes. The rewrite reads from `/proc` and `/sys` instead, dropping those privilege requirements, and discovers the host's power-meter structure at runtime rather than assuming a fixed hardware topology. The authors report that the new `kepler_node_cpu_watts` metric tracks IPMI readings and no longer produces the multi-kilowatt spikes seen on the old path, with per-process attribution drift reduced to a few milliwatts and test coverage at 90 percent.
+
+Dropping the privileged DaemonSet removes a standing objection to running Kepler in security-sensitive clusters, and the post explicitly asks for help validating GPU power, VM power modeling, and accuracy across more hardware.
+
+**Source:** [CNCF blog](https://www.cncf.io/blog/2026/06/30/kepler-re-architected-improved-power-accuracy-and-a-community-call-to-action/) - June 30, 2026
+
+---
+
+## wasmCloud 2.5.0 enables WASI Preview 3 by default
+
+wasmCloud published [v2.5.0](https://github.com/wasmCloud/wasmCloud/releases/tag/v2.5.0) on June 30, updating the runtime to Wasmtime 46 and enabling WASI Preview 3 (wasip3) by default.
+
+WASI Preview 3 brings the component model's native async support. The release adds async variants of the `wasmcloud:keyvalue` and `wasmcloud:blobstore` interfaces and supports wasip3 cross-component streams through the dynamic linker. Components can now multiplex several implementations of a capability — `wasi:keyvalue`, `wasmcloud:postgres`, and `wasmcloud:messaging/consumer` — via `implements` directives in their imports. The keyvalue interface is restructured to share a bucket through a types interface, a breaking change that requires interface updates, and the build adds s390x binaries.
+
+Turning wasip3 on by default is the signal that async in the component model is the runtime's default execution path, not an opt-in preview.
+
+**Source:** [wasmCloud v2.5.0 release](https://github.com/wasmCloud/wasmCloud/releases/tag/v2.5.0) - June 30, 2026
+
+---


### PR DESCRIPTION
## Summary

A short, verified digest of three primary-source items from the last 24 hours: a Flux feature release, a Kepler power-monitoring rewrite, and a wasmCloud runtime bump. The window was otherwise thin — several notable releases fell just outside the strict 24-hour cutoff (see dropped items) — so this ships three strong segments rather than padding.

## Run metadata

- Run time: `2026-07-01 06:00 Europe/London`
- Coverage window: `2026-06-30 05:00 UTC` to `2026-07-01 05:00 UTC`
- Source URLs inspected: `~55` (across 5 discovery scouts + direct fact-checks)
- Candidates longlisted: `~14` verified in-window items
- Candidates shortlisted: `6`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Flux 2.9.0 adds a CLI plugin system and post-quantum SOPS decryption — new extensibility surface, Workload Identity auth, and a breaking v1beta2 CRD removal.
- Kepler replaces eBPF with read-only /proc and /sys for power monitoring — drops CAP_BPF/CAP_SYSADMIN and improves accuracy against IPMI.
- wasmCloud 2.5.0 enables WASI Preview 3 by default — component-model async on Wasmtime 46, plus capability multiplexing.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Flux v2.9.0 published 2026-06-30 15:48 UTC | github.com/fluxcd/flux2/releases/tag/v2.9.0 (release page + API timestamp) | ✅ |
| CLI plugin system (`flux plugin install`, digest pinning, Mirror + Schema plugins) | Flux v2.9.0 release notes | ✅ |
| SOPS Age post-quantum cipher; Workload Identity for OpenBao/Vault + AWS CodeCommit; v1beta2 image/notification API removal | Flux v2.9.0 release notes | ✅ |
| Controller versions (source/kustomize/notification v1.9.1, helm-controller v1.6.1, source-watcher v2.2.1) | Flux v2.9.0 release notes | ✅ |
| Kepler post dated 2026-06-30, authors Manoledaki (Grafana) + Choochotkaew (IBM) | cncf.io/blog/2026/06/30/kepler-re-architected... (byline) | ✅ |
| eBPF → /proc + /sys rewrite; drops CAP_BPF/CAP_SYSADMIN; runtime power-meter discovery; kepler_node_cpu_watts tracks IPMI; ~few-mW attribution drift; 90% test coverage | CNCF Kepler post body | ✅ |
| wasmCloud v2.5.0 published 2026-06-30 19:35 UTC | github.com/wasmCloud/wasmCloud/releases/tag/v2.5.0 (release page + API timestamp) | ✅ |
| Wasmtime 46; wasip3 default; async keyvalue/blobstore; multiplex via `implements`; keyvalue types-interface breaking change; s390x binaries | wasmCloud v2.5.0 release notes | ✅ |

## Items considered and dropped

- Gateway API v1.6.0 GA (UDPRoute/TCPRoute GA, CORS filter) — published 2026-06-29 20:40 UTC, ~8h before the window opened.
- vLLM v0.24.0 (major release: MiniMax-M3, DeepSeek-V4 opts, Model Runner V2) — 2026-06-29 19:41 UTC, before window.
- TensorRT-LLM v1.3.0rc20 (last RC with TensorRT backend) — 2026-06-30 01:11 UTC, before the 05:00 UTC window start.
- Dragonfly v2.5.0 — CNCF *announcement* dated 2026-06-30 but the GitHub release tag is 2026-06-25; the fresh source only points to older material.
- Argo CD v3.5.0-rc2 (2026-07-01 03:35 UTC) — in-window but an RC carrying only bug fixes.
- NVIDIA GQE query-engine and Nsight neural-reconstruction blogs (2026-06-30) — vendor-reported benchmarks / niche; scope-fit weak for the core audience.
- arXiv 2606.29708 "Demystifying Heterogeneous LLM Inference" and 2606.30391 "Festina / Energy-Aware Serverless LLM Serving" — both v1-submitted 2026-06-29 (only the arXiv *announce* date was 06-30); out of window under the submission-timestamp rule.
- llama.cpp nightly build tags (b9844–b9851, 2026-06-30) — individual CUDA/Vulkan commits, too granular for a segment.
- Spin canary (2026-06-30 21:13 UTC) — rolling unstable build, not a tagged release.
- CloudNativePG v1.30.0, OPA v1.18.1 — both 2026-06-29, just before the window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~14 verified in-window
- Segments shipped: 3
- Timestamp caveat: the CNCF Kepler post exposes a date (2026-06-30) but no published time. A CNCF blog post dated the 30th is within the 24h window of a 06:00-London run in every plausible case, so it is treated as in-window; flagging in case a reviewer wants a stricter cut.
- Vendor-attributed claims: none in the shipped segments. Kepler accuracy figures (IPMI tracking, milliwatt attribution drift, 90% coverage) are attributed to the authors' own post — worth reading as project-reported rather than independently benchmarked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFYBFPpcCQ4zPYMYWsTu7t

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYBFPpcCQ4zPYMYWsTu7t)_