### PR TITLE
Rawkode Academy News - July 3, 2026

### DIFF
--- a/content/news/2026-07-03-kubevirt-grace-gpu-disaggregated-llm-serving/index.mdx
+++ b/content/news/2026-07-03-kubevirt-grace-gpu-disaggregated-llm-serving/index.mdx
@@ -7,7 +7,6 @@ authors:
 technologies:
   - kubevirt
   - kubernetes
-  - vllm
 ---
 
 It was a quiet 24 hours for stable releases — the week's larger releases (Prometheus 3.13 LTS, Istio 1.28.10, etcd, cert-manager) all shipped on July 1, just outside the window. So this digest leans on GPU infrastructure: a KubeVirt release candidate that wires up Grace GPU passthrough, and two fresh arXiv systems papers on making LLM inference cheaper and more predictable.

--- a/content/news/2026-07-03-kubevirt-grace-gpu-disaggregated-llm-serving/index.mdx
+++ b/content/news/2026-07-03-kubevirt-grace-gpu-disaggregated-llm-serving/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "KubeVirt 1.9 preview adds Grace GPU passthrough; two papers target disaggregated LLM serving"
+description: "KubeVirt cut its first 1.9 release candidate with NVIDIA Grace GPU passthrough behind a feature gate, and two arXiv systems papers propose deflecting prefill onto decode nodes and an uncertainty-aware advisor for GPU serving configuration."
+publishedAt: 2026-07-03
+authors:
+  - rawkode
+technologies:
+  - kubevirt
+  - kubernetes
+  - vllm
+---
+
+It was a quiet 24 hours for stable releases — the week's larger releases (Prometheus 3.13 LTS, Istio 1.28.10, etcd, cert-manager) all shipped on July 1, just outside the window. So this digest leans on GPU infrastructure: a KubeVirt release candidate that wires up Grace GPU passthrough, and two fresh arXiv systems papers on making LLM inference cheaper and more predictable.
+
+## KubeVirt 1.9.0-rc.0 adds NVIDIA Grace GPU passthrough behind a feature gate
+
+KubeVirt published [v1.9.0-rc.0](https://github.com/kubevirt/kubevirt/releases/tag/v1.9.0-rc.0) on July 2, the first release candidate for the 1.9 line, rolling up 1,564 changes from 107 contributors on top of v1.8.4. It builds on Go 1.26.4 and libvirt 11.10.
+
+The headline addition is a `GraceIOVirtualization` feature gate that configures NVIDIA Grace GPU passthrough using SMMUv3 and IOMMUFD, with ACPI Generic Initiator NUMA topology, NUMA distance mapping, and automatic PCI 64-bit hole sizing — the plumbing needed to pass Grace-class GPUs through to virtual machines on ARM64 hosts. A new Plugin CRD (`plugin.kubevirt.io/v1alpha1`) lets sidecars mutate libvirt domain XML over gRPC through declarative domain and node hooks with CEL-based evaluation, behind a `Plugins` feature gate. The RC also promotes `MigrationPriorityQueue`, `VMExport`, `PanicDevices`, persistent reservation, `ExpandDisk`, IBM Secure Execution, and `VideoConfig` to GA, and moves `WorkloadEncryptionSEV`, `RebootPolicy`, and hotplug volumes to beta.
+
+This is a release candidate, not an upgrade target, but the Grace passthrough path is the piece to watch: it points KubeVirt at ARM GPU hosts ahead of the 1.9 GA.
+
+**Source:** [KubeVirt v1.9.0-rc.0 release](https://github.com/kubevirt/kubevirt/releases/tag/v1.9.0-rc.0) - July 2, 2026
+
+---
+
+## Paper proposes deflecting prefill onto decode nodes in disaggregated serving
+
+A paper submitted to arXiv on July 2, [Towards Load-Aware Prefill Deflection for Disaggregated LLM Serving](https://arxiv.org/abs/2607.02043), targets a known imbalance in prefill/decode disaggregation: under load, the prefill GPU pool saturates while decode GPUs sit underused.
+
+The authors propose a scheduler that estimates time-to-first-token for each queued request on both prefill and decode nodes, then redirects — "deflects" — prefill work onto decode nodes as chunked-prefill steps interleaved with ongoing decode, but only when that improves tail latency without breaking time-between-tokens SLOs. Because a deflected request runs its prefill locally on the decode node, the design skips the inter-node KV-cache transfer that disaggregation normally forces. On production traces with DeepSeek-V2-Lite, the paper reports up to an 81% reduction in P95 TTFT and up to 79% higher SLO attainment over existing disaggregated schedulers, with sub-millisecond routing overhead.
+
+The numbers are the authors' own and are not independently corroborated, but the technique addresses a failure mode anyone running prefill/decode disaggregation will recognise.
+
+**Source:** [arXiv:2607.02043](https://arxiv.org/abs/2607.02043) - July 2, 2026
+
+---
+
+## OmniPilot pairs a calibrated cost model with abstention for GPU serving configuration
+
+Also submitted July 2, [OmniPilot: An Uncertainty-Aware LLM Inference Advisor for Heterogeneous GPU Clusters](https://arxiv.org/abs/2607.01579) recommends serving configurations — GPU type, tensor-parallel degree, and precision — while quantifying how confident it is in each recommendation.
+
+The system uses conformally calibrated quantile regression across eight serving targets and ranks candidate configurations by an economic-utility metric tied to operator preferences. An out-of-distribution detection layer abstains rather than guess on inputs outside its training envelope. Evaluated across A100, H100, and H200 GPUs at four precision levels (460 benchmark runs), the paper reports 6.2% mean absolute percentage error on throughput prediction, 95% top-1 accuracy on configuration ranking, and an abstention layer that flagged all five out-of-distribution test cases, where prediction error otherwise ran 24-46%.
+
+The abstention behaviour is the load-bearing idea: a cost model that declines to answer on unfamiliar hardware and precision combinations, rather than emitting a confident wrong recommendation an operator would act on. As above, the reported numbers are the authors' own.
+
+**Source:** [arXiv:2607.01579](https://arxiv.org/abs/2607.01579) - July 2, 2026
+
+---


### PR DESCRIPTION
## Summary

A three-segment daily digest for the July 2 publishing window. The last 24 hours were quiet for stable releases — the week's larger releases (Prometheus 3.13 LTS, Istio 1.28.10, etcd, cert-manager) all landed on July 1, just outside the window — so this digest leans on GPU infrastructure. It ships one primary-source release candidate and two fresh arXiv systems papers, each with a concrete technical reason to run. No padding.

## Run metadata

- Run time: `2026-07-03 06:00 Europe/London`
- Coverage window: `2026-07-02 05:00 UTC` to `2026-07-03 05:00 UTC`
- Source URLs inspected: `~45` (GitHub release atom feeds across CNCF/infra/AI projects, Kubernetes & CNCF & OpenTelemetry blogs, arXiv cs.DC)
- Candidates longlisted: `9` in-window artifacts
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- KubeVirt 1.9.0-rc.0 adds NVIDIA Grace GPU passthrough behind a feature gate - first 1.9 RC wires up SMMUv3/IOMMUFD Grace passthrough for VMs on ARM64, plus a Plugin CRD and several feature-gate promotions.
- Load-aware prefill deflection for disaggregated LLM serving - deflects prefill onto idle decode nodes to skip inter-node KV-cache transfer; paper reports up to 81% lower P95 TTFT.
- OmniPilot GPU serving-config advisor - calibrated quantile cost model with an abstention layer that declines to recommend on out-of-distribution hardware/precision.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| KubeVirt v1.9.0-rc.0 published July 2, 2026 (17:16 UTC), first 1.9 RC on top of v1.8.4, 1,564 changes / 107 contributors | [github.com/kubevirt/kubevirt release tag](https://github.com/kubevirt/kubevirt/releases/tag/v1.9.0-rc.0) — release header + notes | ✅ |
| `GraceIOVirtualization` gate configures NVIDIA Grace passthrough via SMMUv3/IOMMUFD, ACPI Generic Initiator NUMA, PCI 64-bit hole sizing; Plugin CRD `plugin.kubevirt.io/v1alpha1`; Go 1.26.4 / libvirt 11.10; GA/beta gate promotions | KubeVirt v1.9.0-rc.0 release notes (feature gates + build section) | ✅ |
| "Towards Load-Aware Prefill Deflection for Disaggregated LLM Serving" submitted July 2, 2026; deflects prefill to decode nodes, avoids KV-cache transfer; up to 81% lower P95 TTFT, up to 79% higher SLO attainment on DeepSeek-V2-Lite traces | [arXiv:2607.02043](https://arxiv.org/abs/2607.02043) — abstract | ✅ (numbers attributed to authors) |
| "OmniPilot: An Uncertainty-Aware LLM Inference Advisor for Heterogeneous GPU Clusters" submitted July 2, 2026; conformal quantile regression + abstention; 6.2% MAPE throughput, 95% top-1 config ranking, 460 runs on A100/H100/H200 | [arXiv:2607.01579](https://arxiv.org/abs/2607.01579) — abstract | ✅ (numbers attributed to authors) |

## Items considered and dropped

- **Dapr 1.18.0** - atom feed showed a July 2 timestamp, but the release page reads "released this 10 Jun 15:02"; the July 2 stamp was a notes edit, not the publish. Fails the 24-hour freshness gate.
- **Harbor 2.15.2** (Jul 2 10:08 UTC) - maintenance patch (Go/Trivy/Angular bumps, minor security hardening, no CVEs). Below the technical-substance floor.
- **CRI-O 1.35.5** (Jul 2/3) - bugfix patch (gomaxprocs hook, ImageRef status). Thin.
- **Longhorn 1.11.3** (Jul 2 00:55 UTC), **Envoy Gateway 1.8.2** (Jul 2 03:59 UTC), **CRI-O 1.36.2 / 1.34.10** (Jul 2 00:57 UTC) - published before the 05:00 UTC window start; also patch-level.
- **Prometheus 3.13.0 LTS, Istio 1.28.10, etcd releases, cert-manager 1.21.0-beta.0, argo-cd 3.5.0-rc2** - all July 1, outside the 24-hour window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `9` in-window artifacts across `~45` inspected sources
- Segments shipped: `3`
- Any unresolved framing concerns: The digest is arXiv-heavy (2 of 3 segments). This reflects a genuinely quiet release window, not a discovery gap — the stable-release wave was July 1. Both papers are distinct problems (scheduling/deflection vs. config advisory) with concrete, quantified contributions, and are framed as preprints.
- Any vendor-attributed claims: All benchmark numbers in the two arXiv segments are the authors' own and are explicitly marked as not independently corroborated. The KubeVirt segment is framed as a release candidate, not an upgrade target.

## Note on repository conventions

This repo's `news` collection uses `content/news/{slug}/index.mdx` with frontmatter fields `title`, `description`, `publishedAt`, `authors`, `technologies` (per `content.config.ts`), so the file follows that schema rather than the `tags`/`draft` shape in the generic playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCRRiM3q5TKayX6abM2isZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCRRiM3q5TKayX6abM2isZ)_