### PR TITLE
Rawkode Academy News - July 4, 2026

### DIFF
--- a/content/news/2026-07-04-otel-semconv-cilium-argo-rollouts/index.mdx
+++ b/content/news/2026-07-04-otel-semconv-cilium-argo-rollouts/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "OpenTelemetry semconv 1.43.0 promotes CI/CD conventions, Cilium 1.20 drops libnetwork, Argo Rollouts cuts first 1.10 RC"
+description: "OpenTelemetry semantic conventions v1.43.0 moves the CI/CD, VCS, and process convention groups to release-candidate stability, Cilium's 1.20 pre-release removes the Docker libnetwork plugin and adds Gateway API L4 routing, and Argo Rollouts tagged its first 1.10 release candidate."
+publishedAt: 2026-07-04
+authors:
+  - rawkode
+technologies:
+  - opentelemetry
+  - cilium
+  - argo
+---
+
+The July 3 window was quiet: no GA milestone releases, merged KEPs, CVEs, or governance moves crossed the wire over the US holiday weekend. Three fresh primary-source releases still stood out — a substantive OpenTelemetry spec release, a Cilium 1.20 pre-release, and the first Argo Rollouts 1.10 release candidate. This is a short digest rather than a padded one.
+
+## OpenTelemetry semantic conventions 1.43.0 promotes CI/CD, VCS, and process conventions to release candidate
+
+OpenTelemetry published [semantic-conventions v1.43.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.43.0) on July 3, an incremental release over v1.42.0 that advances several convention groups toward stability.
+
+The release promotes the CI/CD conventions (spans, metrics, logs, attributes, and entity), the VCS attribute, entity, and metric conventions, and the process metrics and entity to release-candidate status, along with the disk, network, and system direction attributes. It adds an `azure.resource_group.name` resource attribute and `kotlin` as a `telemetry.sdk.language` value. On the breaking side, the Oracle guidance for `db.query.text` now recommends parameterized queries by default, and the signal requirement-level documentation deprecates its metric-specific version.
+
+Because these conventions flow downstream into every OTel SDK and instrumentation library, RC promotion means teams building CI/CD or VCS telemetry can adopt those attribute names with lower churn risk before they reach stable.
+
+**Source:** [OpenTelemetry Semantic Conventions v1.43.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.43.0) - July 3, 2026
+
+---
+
+## Cilium 1.20 pre-release removes the Docker libnetwork plugin and adds Gateway API L4 routing
+
+Cilium published [v1.20.0-pre.4](https://github.com/cilium/cilium/releases/tag/v1.20.0-pre.4) on July 3, a pre-release on the road to 1.20 that lands several networking changes.
+
+The pre-release adds beta IPv6 support to ENI IPAM mode, allowing IPv6 prefix allocation on that path, and introduces TCPRoute and UDPRoute support for the Gateway API, extending Cilium's Gateway API implementation to L4 traffic. It also sunsets the Docker libnetwork plugin, which is no longer available — operators still depending on it will need to migrate before upgrading to 1.20.
+
+As a pre-release, these features are preview-stage and can still change before 1.20 GA, but the libnetwork removal is a concrete signal for anyone tracking the 1.20 upgrade path.
+
+**Source:** [Cilium v1.20.0-pre.4](https://github.com/cilium/cilium/releases/tag/v1.20.0-pre.4) - July 3, 2026
+
+---
+
+## Argo Rollouts cuts its first 1.10 release candidate
+
+The Argo Rollouts team tagged [v1.10.0-rc1](https://github.com/argoproj/argo-rollouts/releases/tag/v1.10.0-rc1) on July 3, the first release candidate of the 1.10 line for the progressive-delivery controller.
+
+The candidate makes Traefik API group v3 the default for the Traefik traffic router, moves the build to Go 1.26 and a Debian 12 base image, and makes the Datadog metric provider's request timeout configurable. It also fixes a correctness bug where analysis runs could report success prematurely when a ReplicaSet became unsaturated, and reduces controller memory by filtering the ReplicaSet informer and converting unstructured objects to typed structures.
+
+The changelog spans the full cycle since v1.9.0; the RC itself is the fresh signal that 1.10 is nearing GA and is ready for pre-production testing.
+
+**Source:** [Argo Rollouts v1.10.0-rc1](https://github.com/argoproj/argo-rollouts/releases/tag/v1.10.0-rc1) - July 3, 2026
+
+---

--- a/content/news/2026-07-04-otel-semconv-cilium-argo-rollouts/index.mdx
+++ b/content/news/2026-07-04-otel-semconv-cilium-argo-rollouts/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenTelemetry semconv 1.43.0 promotes CI/CD conventions, Cilium 1.20 drops libnetwork, Argo Rollouts cuts first 1.10 RC"
-description: "OpenTelemetry semantic conventions v1.43.0 moves the CI/CD, VCS, and process convention groups to release-candidate stability, Cilium's 1.20 pre-release removes the Docker libnetwork plugin and adds Gateway API L4 routing, and Argo Rollouts tagged its first 1.10 release candidate."
+description: "OpenTelemetry semantic conventions v1.43.0 moves the CI/CD, VCS, and process convention groups to release-candidate status, Cilium's 1.20 pre-release removes the Docker libnetwork plugin and adds Gateway API L4 routing, and Argo Rollouts tagged its first 1.10 release candidate."
 publishedAt: 2026-07-04
 authors:
   - rawkode


### PR DESCRIPTION
## Summary

The July 3 window (24h to 2026-07-04 06:00 Europe/London) was quiet over the US holiday weekend: no GA milestone releases, merged KEPs, CVEs/GHSAs, arXiv systems papers, or CNCF governance moves landed in-window. Three fresh primary-source releases still cleared the bar — one substantive OpenTelemetry spec release plus two pre-GA release cuts from flagship CNCF projects, each with concrete, verifiable content. Weaker in-window items (a score-compose point release, llama.cpp per-commit rolling tags, a CNCF member marketing post) were dropped rather than padding the digest to a target count.

## Run metadata

- Run time: `2026-07-04 06:15 Europe/London`
- Coverage window: `2026-07-03T05:15Z` to `2026-07-04T05:15Z`
- Source URLs inspected: `~120` (5 parallel discovery scouts + editor cross-checks; GitHub release atom feeds, project blogs, arXiv, GHSA database, CNCF announcements)
- Candidates longlisted: `~10` in-window items
- Candidates shortlisted: `4`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- OpenTelemetry semantic conventions 1.43.0 promotes CI/CD, VCS, and process conventions to release candidate — attribute names stabilizing for downstream SDK/instrumentation authors.
- Cilium 1.20 pre-release removes the Docker libnetwork plugin and adds Gateway API L4 routing — concrete migration signal and L4 (TCPRoute/UDPRoute) Gateway API coverage for the 1.20 upgrade path.
- Argo Rollouts cuts its first 1.10 release candidate — Traefik v3 default, Go 1.26/Debian 12, and a blue-green analysis correctness fix, signalling 1.10 is nearing GA.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| semconv v1.43.0 published 2026-07-03T20:14:31Z, incremental over v1.42.0 | github.com/open-telemetry/semantic-conventions releases.atom + release tag page | ✅ |
| CI/CD, VCS, process conventions + disk/network/system direction attrs promoted to RC | semantic-conventions v1.43.0 release notes | ✅ |
| Adds `azure.resource_group.name`, `kotlin` telemetry.sdk.language; Oracle `db.query.text` parameterized-query guidance (breaking) | semantic-conventions v1.43.0 release notes | ✅ |
| Cilium v1.20.0-pre.4 published 2026-07-03T20:50:44Z | github.com/cilium/cilium releases.atom + release tag page | ✅ |
| pre.4 adds beta IPv6 ENI IPAM, Gateway API TCPRoute/UDPRoute, sunsets Docker libnetwork plugin | cilium v1.20.0-pre.4 "Summary of Changes" (PRs #46756, #46184, #46489) | ✅ |
| Argo Rollouts v1.10.0-rc1 published 2026-07-03T12:53:46Z, first 1.10 RC (cumulative since v1.9.0) | github.com/argoproj/argo-rollouts releases.atom + release tag page | ✅ |
| Traefik API group v3 default, Go 1.26, Debian 12 base, Datadog timeout configurable, analysis premature-success fix, ReplicaSet informer memory reduction | argo-rollouts v1.10.0-rc1 release notes | ✅ |

## Items considered and dropped

- score-compose 0.42.0 (2026-07-03T22:11Z) — in-window but thin: metadata validation tweaks + Kafka provisioner image swap off Bitnami. Below the substance bar.
- llama.cpp b9862–b9870 (2026-07-03) — automated per-commit rolling release tags, not real releases.
- CNCF blog "How data sovereignty is changing cloud native infrastructure design" (2026-07-03T11:00Z) — CNCF member/vendor marketing post, limited technical substance.
- OTel Collector `v0.156.0-nightly.202607040307` — automated nightly build, not a release.
- Near-misses just outside the window (dropped for freshness): Prometheus 3.13.0 GA (07-01), etcd 3.6.13/3.5.32 (07-01), Istio 1.28.10 (07-01), Argo CD v3.5.0-rc2 (07-01), cri-o 1.36.2 (07-02), rekor 1.5.3 (07-02), wasmCloud 2.5.1 (07-02), Grafana 13.1.0 (07-01).

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~10 in-window; 4 shortlisted; 3 shipped
- Segments shipped: 3 (at the floor — not padded)
- Framing concern: two of three segments are pre-GA (a pre-release and a first RC). Each is framed explicitly as pre-release/RC, the fresh event is the release cut itself, and pre.4's headline features were verified to have landed in this specific pre-release rather than only carried cumulatively. If the editorial preference is GA-only, the Cilium and Argo Rollouts segments are the ones to reconsider — but both are honest, primary-sourced release events.
- Vendor-attributed claims: none. All claims trace to official project GitHub release notes (Tier 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013G4cVJCMSXauP1A6gvCtwP)_