### PR TITLE
Rawkode Academy News - July 7, 2026

### DIFF
--- a/content/news/2026-07-07-otel-semconv-vllm-hunyuan-atproto/index.mdx
+++ b/content/news/2026-07-07-otel-semconv-vllm-hunyuan-atproto/index.mdx
@@ -1,0 +1,60 @@
+---
+title: "OpenTelemetry JS stabilizes Kubernetes semconv, vLLM upstreams Hunyuan MoE backends, atproto tightens protocol validation"
+description: "OpenTelemetry JS promoted 46 Kubernetes and container attributes to stable and split GenAI conventions into a new package, vLLM upstreamed Tencent Hunyuan's FP8 MoE and attention backends for Hopper, and atproto added standards-compliant rate-limit headers."
+publishedAt: 2026-07-07
+authors:
+  - rawkode
+technologies:
+  - opentelemetry
+  - kubernetes
+---
+
+Four primary-source items landed in the last 24 hours across observability, inference serving, open protocols, and training-systems research. Most of the week's larger releases shipped just before the window, so this is a short, verified digest rather than a padded one.
+
+## OpenTelemetry JS promotes Kubernetes and container attributes to stable, splits GenAI conventions into a new package
+
+The OpenTelemetry JS project published [semantic-conventions v1.42.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.42.0) on July 6, promoting 46 container and Kubernetes resource attribute exports to stable and deprecating 74 GenAI and MCP exports from the main package.
+
+The stable additions cover container identity plus Kubernetes cluster, pod, deployment, daemonset, cronjob, job, replicaset, statefulset, namespace, and node attributes, freezing the API surface for the resource-detection paths most instrumentation relies on. The release also adds 16 incubating exports, including filesystem locks, browser document URLs, GCP instance labels, and app crash events. The 74 deprecated GenAI and MCP exports move to the OpenTelemetry GenAI semantic-conventions repository and will ship from a separate `@opentelemetry/semantic-conventions-genai` package.
+
+Anyone importing GenAI or MCP conventions from `@opentelemetry/semantic-conventions` will need to migrate to the new package once it publishes; the Kubernetes and container attributes already in use are now stable API.
+
+**Source:** [OpenTelemetry JS semantic-conventions v1.42.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.42.0) - July 6, 2026
+
+---
+
+## vLLM upstreams Tencent Hunyuan's FP8 MoE and attention backends for Hopper
+
+The vLLM team and Tencent Hunyuan's AI infra team published [attention and mixture-of-experts backends](https://vllm.ai/blog/2026-07-06-vllm-hpc-ops) for vLLM on July 6, tuned for the Hunyuan Hy3 model series on NVIDIA Hopper GPUs.
+
+The attention backend pairs a per-step, load-balanced decode scheduler with a fused RoPE, QK-Norm, and KV-write prologue and runs in BF16 or FP8; the MoE path is a fully fused FP8 pipeline aimed at Hy3's 192-expert, top-8 routing at a 256K context window. On 8× H20, the authors report roughly a 24% reduction in time-to-first-token and 17% in time-per-output-token for end-to-end Hy3 serving, with the attention kernel reaching up to 2.95× over a static split-KV schedule and the MoE kernel averaging 1.59× at TP8/EP1 over Triton and CUTLASS. The figures are the authors' own benchmarks.
+
+Because these land upstream, the scheduling and FP8 MoE work is available to any vLLM deployment serving large MoE models on Hopper-class hardware, not only Hunyuan.
+
+**Source:** [vLLM blog](https://vllm.ai/blog/2026-07-06-vllm-hpc-ops) - July 6, 2026
+
+---
+
+## atproto adds standards-compliant rate-limit headers and stricter language-tag parsing
+
+The atproto monorepo cut a batch of package releases on July 6, led by rate-limit and validation changes to the reference AT Protocol server implementation.
+
+[`@atproto/xrpc-server@0.11.7`](https://github.com/bluesky-social/atproto/releases) now returns a `Retry-After` header on rate-limited responses, giving clients a standard backoff signal instead of a bare 429. `@atproto/syntax@0.7.0` tightens `parseLanguageString` to reject BCP 47 tags with duplicate variant subtags or duplicate extension singleton subtags, per RFC 5646 §4.1, closing a gap in the language-tag validation used across lexicon and record parsing. The same batch shipped point updates to `@atproto/pds`, `ozone`, `sync`, `repo`, and `xrpc`, mostly dependency bumps.
+
+For PDS operators, the `Retry-After` change makes rate limiting legible to well-behaved clients, and the stricter parser rejects malformed language tags at the boundary rather than persisting them.
+
+**Source:** [atproto releases](https://github.com/bluesky-social/atproto/releases) - July 6, 2026
+
+---
+
+## Paper proposes checkpoint-free state migration for elastic LLM training
+
+A paper submitted to arXiv on July 6, [Direct Model State Migration for Elastic Training of Large Language Models](https://arxiv.org/abs/2607.04749), describes ETC, a system that reconfigures hybrid-parallel training across changing GPU allocations without writing checkpoints to disk.
+
+Elastic training normally persists full model state to storage before resharding to a new parallel layout, stalling the job on checkpoint I/O. ETC instead exploits state locality to move only what each GPU needs through direct peer-to-peer transfers, and coalesces communication to avoid node fragmentation. The authors report a 2.33× to 6.37× reduction in migration overhead versus checkpoint-based approaches across parallel configurations, and state that the system is integrated with Megatron-LM.
+
+For teams training on preemptible or elastic GPU pools, migration cost is what makes rescaling expensive; cutting it changes how aggressively a scheduler can reshape a running job.
+
+**Source:** [arXiv 2607.04749](https://arxiv.org/abs/2607.04749) - July 6, 2026
+
+---


### PR DESCRIPTION
## Summary

A four-segment daily digest for the July 6 publishing window. It was a quiet 24 hours — the week's larger releases (Cilium 1.20.0-pre.4, Prometheus 3.13.0, Istio 1.28.10, Flux 2.9.0, vLLM 0.24.0) all landed just before the window — so this ships only primary-sourced, in-scope items that passed the freshness gate: an OpenTelemetry JS semantic-conventions stabilization, an upstream vLLM MoE/attention contribution from Tencent Hunyuan, a rate-limit and validation batch in the atproto reference server, and a fresh arXiv systems paper on elastic-training state migration. No padding.

## Run metadata

- Run time: `2026-07-07 06:00 Europe/London`
- Coverage window: `2026-07-06 05:00 UTC` to `2026-07-07 05:00 UTC`
- Source URLs inspected: `~110` (four parallel discovery sweeps across CNCF/Kubernetes, AI/HPC, observability/mesh, and platform/security/wasm, each fetching release atom feeds, project blogs, arXiv, and CVE feeds)
- Candidates longlisted: `~14 in-window`
- Candidates shortlisted: `6`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- OpenTelemetry JS promotes Kubernetes and container attributes to stable, splits GenAI conventions into a new package — freezes the common resource-detection API surface and forces a GenAI/MCP import migration.
- vLLM upstreams Tencent Hunyuan's FP8 MoE and attention backends for Hopper — brings a fused FP8 MoE pipeline and load-balanced decode scheduler to any Hopper-class MoE serving deployment.
- atproto adds standards-compliant rate-limit headers and stricter language-tag parsing — `Retry-After` on 429s plus RFC 5646 §4.1 BCP-47 validation in the reference PDS/XRPC server.
- Paper proposes checkpoint-free state migration for elastic LLM training — ETC reports a 2.33×–6.37× cut in migration overhead versus checkpointing, integrated with Megatron-LM.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| semconv v1.42.0 promotes 46 container/K8s attrs to stable, adds 16 incubating, deprecates 74 GenAI/MCP exports to a new `@opentelemetry/semantic-conventions-genai` package | [OTel JS release semconv/v1.42.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.42.0), release body; timestamp 2026-07-06T19:27Z via releases.atom | ✅ |
| vLLM/Hunyuan attention up to 2.95× over static split-KV; MoE avg 1.59× at TP8/EP1 over Triton/CUTLASS; e2e Hy3 on 8×H20 ~24% TTFT / ~17% TPOT reduction (authors' benchmarks) | [vLLM blog 2026-07-06-vllm-hpc-ops](https://vllm.ai/blog/2026-07-06-vllm-hpc-ops), post body; byline "Jul 6, 2026" | ✅ (vendor/project-attributed) |
| Hy3 = 192 experts, top-8 routing, 256K context; backends target NVIDIA Hopper / H20; BF16+FP8 attention, FP8 MoE | [vLLM blog](https://vllm.ai/blog/2026-07-06-vllm-hpc-ops), post body | ✅ |
| `@atproto/xrpc-server@0.11.7` adds `Retry-After` on rate-limited responses (PR #5158) | [atproto releases](https://github.com/bluesky-social/atproto/releases), release notes; timestamp 2026-07-06T17:29Z via releases.atom | ✅ |
| `@atproto/syntax@0.7.0` rejects BCP 47 tags with duplicate variant/extension subtags per RFC 5646 §4.1 (PR #5162) | [atproto releases](https://github.com/bluesky-social/atproto/releases), release notes | ✅ |
| ETC reports 2.33×–6.37× migration-overhead reduction vs checkpoint-based; integrated with Megatron-LM | [arXiv 2607.04749](https://arxiv.org/abs/2607.04749), abstract; submitted 2026-07-06T07:39Z | ✅ |

## Items considered and dropped

- **NVIDIA "Nonuniform Tensor Parallelism" blog (Jul 6)** — the blog is fresh, but the underlying technique and paper (arXiv 2504.06095) date to April 2025 and the figures are vendor benchmarks; fails the freshness/vendor-positioning gates.
- **Kargo v1.11.0-rc.1 (Jul 6, Tier 1)** — release notes are empty ("No content"), so no technical substance could be verified; dropped per the no-unverifiable-claims rule. (Also an RC.)
- **arXiv 2607.05116 CAP — communication-aware MoE inference placement/pruning (Jul 6)** — legitimate and in-window (1.23×–1.86× throughput over DeepSeek EPLB in vLLM), cut to avoid a second MoE item and over-weighting AI; worth a look.
- **Perses v0.54.0-beta.3 (Jul 6, Tier 1)** — carries a security fix (project query-param misuse, no CVE) but is a beta pre-release with thin actionability.
- **OpenTelemetry Collector nightlies / llama.cpp per-commit builds** — automated CI artifacts, not discrete releases.
- **CNCF member blog posts (platform-eng / SRE, Jul 6)** — Tier 3 opinion/positioning with no primary technical artifact.
- **arXiv 2607.04935 TARE (HPC job-runtime prediction eval)** — in-window but methodology-only, low news value.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~14 in-window (of ~110 URLs inspected)
- Segments shipped: 4
- Any unresolved framing concerns: The vLLM blog's publish time is confirmed at day-level (July 6) but its exact UTC time is not exposed on the page; given the slug (`2026-07-06`) and US-daytime publishing it is in-window. All other timestamps are precisely verified via GitHub `releases.atom` `<updated>` fields or arXiv submission history.
- Any vendor-attributed claims: The vLLM/Hunyuan performance figures are the authors' own benchmarks and are attributed as such in the segment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XUpqn1QJXsXKA7odxWwF1J)_