### PR TITLE
Rawkode Academy News - July 8, 2026

### DIFF
--- a/content/news/2026-07-08-nccl-2-30-7-flux-2-9-1-otel-collector-0-156/index.mdx
+++ b/content/news/2026-07-08-nccl-2-30-7-flux-2-9-1-otel-collector-0-156/index.mdx
@@ -1,0 +1,43 @@
+---
+title: "NCCL 2.30.7 adds zero-SM collectives, Flux 2.9.1 stops CRD schema corruption, OpenTelemetry Collector 0.156 fixes a pipeline startup race"
+description: "NVIDIA's NCCL 2.30.7 introduces experimental zero-SM collectives for compute-communication overlap, while Flux 2.9.1 stops post-build substitution from corrupting CRD schemas and OpenTelemetry Collector 0.156.0 fixes a pipeline startup race and duplicate OTLP/HTTP exports."
+publishedAt: 2026-07-08
+authors:
+  - rawkode
+technologies:
+  - opentelemetry
+  - fluxcd
+  - kubernetes
+---
+
+Three primary-source releases landed in the last 24 hours across GPU collective communication, GitOps, and observability. It was a quiet window, so this is a short digest rather than a padded one.
+
+## NCCL 2.30.7 adds experimental zero-SM collectives for compute-communication overlap
+
+NVIDIA published [NCCL v2.30.7-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1) on July 8, the latest patch on the collective communication library's 2.30 branch. The headline addition is hierarchical zero-SM AllGather and All2all collectives that route inter-node traffic through an RMA CPU proxy, enabled with `NCCL_CTA_POLICY_ZERO`.
+
+Moving those collectives off streaming multiprocessors frees SM cycles for compute, which is what teams want when overlapping communication with kernels in large-scale training and inference. The release also adds an experimental GPU Push Interface (GPI) backend for GIN with explicit strong and weak signal semantics, window registration during CUDA graph capture, support for asymmetric buffer sizes during window registration, and MPS support for up to two ranks per physical GPU via CUDA's Memory Locality Optimized Partition (MLOPart). It optimizes the ReduceScatter symmetric kernel, adds batched copy-engine operations on the RMA put/wait path, and fixes a deadlock under PXN during runtime buffer memsetting. Support for GIN plugin API versions 11 and 12 is dropped.
+
+**Source:** [NVIDIA NCCL v2.30.7-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1) - July 8, 2026
+
+---
+
+## Flux 2.9.1 disables variable substitution on its own CRDs to stop schema corruption
+
+The Flux team shipped [v2.9.1](https://github.com/fluxcd/flux2/releases/tag/v2.9.1) on July 7, a patch release for the GitOps toolkit. The primary fix annotates all Flux CRDs to disable Flux's post-build variable substitution on them, so substitution can no longer rewrite `${...}` sequences inside CRD OpenAPI schemas and corrupt them when Flux manages its own CRDs through a Kustomization.
+
+The release also updates SOPS to fix decryption of `.ini` files in kustomize-controller, resolves a dry-run failure when applying resources with strategic merge patches, and caches registry authorization tokens in source-controller to speed up Notation signature verification. Anyone running Flux to reconcile its own CRDs with post-build substitution enabled should take this patch.
+
+**Source:** [Flux v2.9.1](https://github.com/fluxcd/flux2/releases/tag/v2.9.1) - July 7, 2026
+
+---
+
+## OpenTelemetry Collector 0.156.0 fixes a pipeline startup race and duplicate OTLP/HTTP exports
+
+The OpenTelemetry Collector released [v0.156.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.156.0) on July 7. The core release fixes a race in the service where receivers could begin emitting telemetry before all pipeline components had finished initializing, which could drop or misroute early data.
+
+It also changes the OTLP/HTTP exporter to treat parsing errors on successful (2xx) responses as permanent rather than retryable, avoiding duplicate exports when a response body exceeds the 64kB read limit. The `memory_limiter` processor gains exponential backoff when garbage collection is ineffective, so it stops burning CPU while a downstream exporter is failing, and now reports health via component status. One breaking change ships alongside the fixes: `pkg/pprofile` adds bounds checks to `FromAttributeIndices`, altering behavior for profile attribute handling.
+
+**Source:** [OpenTelemetry Collector v0.156.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.156.0) - July 7, 2026
+
+---


### PR DESCRIPTION
## Summary

A short, three-segment daily digest covering primary-source releases from the last 24 hours: NVIDIA's NCCL 2.30.7 (experimental zero-SM collectives and RMA/MPS work for AI/HPC), Flux 2.9.1 (a correctness fix that stops post-build substitution from corrupting Flux's own CRD schemas), and OpenTelemetry Collector 0.156.0 (a pipeline startup race and a duplicate-export fix). The window was quiet, so the digest is deliberately short rather than padded — routine patch releases, prereleases, and unverified preprints were dropped.

## Run metadata

- Run time: `2026-07-08 06:00 Europe/London`
- Coverage window: `2026-07-07 06:00 Europe/London` to `2026-07-08 06:00 Europe/London`
- Source URLs inspected: `~45` (project release feeds, release pages, changelogs, project/CNCF/Kubernetes blogs, arXiv cs.DC)
- Candidates longlisted: `12`
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- NCCL 2.30.7 adds experimental zero-SM collectives - moves AllGather/All2all off SMs via an RMA CPU proxy so cycles free up for compute overlap in large training/inference jobs.
- Flux 2.9.1 disables variable substitution on its own CRDs - stops post-build substitution from rewriting `${...}` in CRD schemas and corrupting them.
- OpenTelemetry Collector 0.156.0 fixes a pipeline startup race - receivers no longer emit before pipeline components finish initializing; OTLP/HTTP exporter stops duplicating exports on large 2xx bodies.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| NCCL v2.30.7-1 published 2026-07-08 (01:10 UTC), within window | github.com/NVIDIA/nccl releases feed + release tag v2.30.7-1 | ✅ |
| Zero-SM AllGather/All2all via RMA CPU proxy, enabled by `NCCL_CTA_POLICY_ZERO` | NCCL v2.30.7-1 release notes, New Features | ✅ |
| Experimental GPI backend for GIN; MPS up to 2 ranks/GPU via MLOPart; ReduceScatter symmetric-kernel optimization; PXN deadlock fix; GIN plugin API v11/v12 dropped | NCCL v2.30.7-1 release notes | ✅ |
| Flux v2.9.1 published 2026-07-07 (13:55 UTC), within window | github.com/fluxcd/flux2 releases feed + release tag v2.9.1 | ✅ |
| v2.9.1 annotates all Flux CRDs to disable post-build substitution to prevent CRD schema corruption | Flux v2.9.1 release notes | ✅ |
| SOPS `.ini` decryption fix in kustomize-controller; strategic-merge-patch dry-run fix; Notation registry token caching in source-controller | Flux v2.9.1 release notes | ✅ |
| OpenTelemetry Collector v0.156.0 (core) published 2026-07-07 (14:40 UTC), within window | github.com/open-telemetry/opentelemetry-collector releases feed + release tag v0.156.0 | ✅ |
| pkg/service race: receivers could emit before pipeline components initialized | Collector core v0.156.0 changelog, Bug Fixes | ✅ |
| otlphttp exporter treats parse errors on 2xx as permanent to avoid duplicate exports over 64kB; memory_limiter exponential backoff; pkg/pprofile FromAttributeIndices bounds-check (breaking) | Collector core v0.156.0 changelog | ✅ |

## Items considered and dropped

- Argo Workflows v4.0.7 / v3.7.16 (2026-07-07) - routine patch; frontend dependency security bumps (`linkify-it`, `@babel/core`) and minor bug fixes, no CVE or practitioner-facing story.
- vLLM v0.25.0rc1 (2026-07-08) - release candidate, not stable; routine biweekly RC with no headline feature verified in window.
- Backstage v1.53.0-next.2 (2026-07-07) - weekly `next` prerelease, not a stable release.
- Spin `canary` / Wasmtime dev tag (2026-07-07) - rolling development builds, not releases.
- arXiv cs.DC systems preprints (UBEP expert-parallelism comms, Communication-Aware MoE placement/pruning, MatrixFSDP, KV-cache serving surveys) - fresh but unverified preprints; held for human review rather than shipped without corroboration.
- Prometheus 3.13.0, Istio 1.28.10, etcd 3.6.13, Argo CD 3.5.0-rc2, Dapr 1.18.x, Grafana 13.1.0, Harbor 2.15.2 - all released July 1-2, outside the 24h window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `12`
- Segments shipped: `3`
- Any unresolved framing concerns: none. NCCL zero-SM collectives and the GPI/GIN backend are labelled experimental in the release notes and framed as such in the segment.
- Any vendor-attributed claims: none requiring attribution; all three items are primary-source project releases with the changes taken directly from release notes/changelogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR8jehzMNZYicwvtMSEymW)_