### PR TITLE
Rawkode Academy News - July 10, 2026

### DIFF
--- a/content/news/2026-07-10-cert-manager-1-21-coredns-gatekeeper-argocd/index.mdx
+++ b/content/news/2026-07-10-cert-manager-1-21-coredns-gatekeeper-argocd/index.mdx
@@ -38,7 +38,7 @@ The forward plugin gains DNS-over-HTTPS for upstream queries and a configurable 
 
 OPA Gatekeeper cut [v3.23.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.23.0) on July 9. The mutation `ApplyTo` specification gains an `operations` field, letting policy authors scope mutations to specific admission operations rather than applying them broadly. The release also adds a remote-cluster mode that routes status resources for deployments watching an external cluster, and moves internal logging to structured, semantic log lines.
 
-Under the hood, OCI artifact pulls migrate to oras-go v2, and audit and validation paths get hardening — including transient-failure handling in Validating Admission Policy API discovery and TLS readiness gating for the webhook servers — across roughly twenty bug fixes. The release bumps its Kubernetes libraries to 1.36.2 and pulls in a golang/net security fix.
+Under the hood, OCI artifact pulls migrate to oras-go v2, and audit and validation paths get hardening — including transient-failure handling in Validating Admission Policy API discovery and TLS readiness gating for the webhook servers — across roughly twenty bug fixes. The release bumps its Kubernetes libraries to 1.36.2 and pulls in a `golang.org/x/net` security fix.
 
 **Source:** [Gatekeeper v3.23.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.23.0) - July 9, 2026
 
@@ -60,6 +60,6 @@ containerd released [1.7.34](https://github.com/containerd/containerd/releases/t
 
 The changes concentrate on CRI and sandbox lifecycle stability: fixes for lost container exit events that arrive before container info is cached, a nil-pointer path during NRI IP lookup, rejecting container creation when the sandbox is not running, and cleaning up sandboxes correctly when a hook fails. Because the runtime underpins most Kubernetes nodes, clusters hitting stuck-container or sandbox-cleanup edge cases are the ones that should schedule the patch.
 
-**Source:** [containerd 2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3) - July 9, 2026
+**Source:** [containerd 2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3) - July 10, 2026
 
 ---

--- a/content/news/2026-07-10-cert-manager-1-21-coredns-gatekeeper-argocd/index.mdx
+++ b/content/news/2026-07-10-cert-manager-1-21-coredns-gatekeeper-argocd/index.mdx
@@ -1,0 +1,65 @@
+---
+title: "cert-manager 1.21 lands ACME renewal hints and Vault IAM auth, CoreDNS hardens DoH, Gatekeeper adds mutation scoping"
+description: "cert-manager 1.21.0 adds ACME Renewal Information and AWS IAM authentication for the Vault issuer while tightening default RBAC, alongside fresh releases from CoreDNS, OPA Gatekeeper, Argo CD, and containerd."
+publishedAt: 2026-07-10
+authors:
+  - rawkode
+technologies:
+  - cert-manager
+  - coredns
+  - opa
+  - argo
+  - containerd
+---
+
+An active patch-and-release window across the cloud native control plane in the last 24 hours: one feature release each from cert-manager, CoreDNS, and OPA Gatekeeper, a correctness fix for Argo CD's auto-sync, and a coordinated containerd patch wave. All five are primary-source releases.
+
+## cert-manager 1.21.0 adds ACME renewal hints and Vault IAM auth, and tightens default RBAC
+
+cert-manager published [v1.21.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0) on July 9. Behind the `ACMEUseARI` feature gate, it adds experimental support for ACME Renewal Information (RFC 9773), letting cert-manager query the ACME server for renewal recommendations rather than relying solely on `renewBefore` timing — useful during mass revocations or CA key rollovers. The Vault issuer now authenticates with AWS IAM via IRSA, EKS Pod Identity, or ambient EC2/ECS credentials, removing the need for long-lived AWS secrets, and a new `renewalPolicies` field on the Certificate API gives finer control over renewal scheduling.
+
+Three Helm-chart breaking changes need attention before upgrading. The chart no longer ships a default Role and RoleBinding letting the controller create tokens for its own ServiceAccount; deployments relying on that must add their own RBAC or move to a dedicated ServiceAccount. The `cert-manager-edit` ClusterRole no longer grants `create` on Challenges and Orders, since those are internal ACME resources — hardening that follows the earlier DNS01 solver-bypass advisory ([GHSA-8rvj-mm4h-c258](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258), fixed in 1.19.6 and 1.20.3). Finally, three ServiceMonitor/PodMonitor Helm values were removed and the metrics port was renamed from `tcp-prometheus-servicemonitor` to `http-metrics`, which will break scrape configs that reference the old name.
+
+**Source:** [cert-manager v1.21.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0) - July 9, 2026
+
+---
+
+## CoreDNS 1.14.5 hardens DoH/DoH3 handling and adds DoH upstreams to the forward plugin
+
+CoreDNS released [v1.14.5](https://github.com/coredns/coredns/releases/tag/v1.14.5) on July 10 with a batch of DNS transport-security fixes. The server now sanitizes DoH and DoH3 request parse errors to avoid leaking information from malformed requests, switches to Go's default TLS settings, and bounds DoQ stream reads by the server read timeout to limit resource exhaustion on QUIC connections.
+
+The forward plugin gains DNS-over-HTTPS for upstream queries and a configurable per-upstream read timeout, and restores the older behavior of continuing on an empty configuration file. The dnstap plugin picks up reliability fixes: closing the previous connection before reconnecting, resolving a self-deadlock during client flush errors, and storing IPv4-mapped IPv6 addresses as four octets with the correct socket family. For operators running CoreDNS as cluster DNS, the transport-security changes are the ones to read closely.
+
+**Source:** [CoreDNS v1.14.5](https://github.com/coredns/coredns/releases/tag/v1.14.5) - July 10, 2026
+
+---
+
+## OPA Gatekeeper 3.23.0 adds mutation operation scoping and remote-cluster status routing
+
+OPA Gatekeeper cut [v3.23.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.23.0) on July 9. The mutation `ApplyTo` specification gains an `operations` field, letting policy authors scope mutations to specific admission operations rather than applying them broadly. The release also adds a remote-cluster mode that routes status resources for deployments watching an external cluster, and moves internal logging to structured, semantic log lines.
+
+Under the hood, OCI artifact pulls migrate to oras-go v2, and audit and validation paths get hardening — including transient-failure handling in Validating Admission Policy API discovery and TLS readiness gating for the webhook servers — across roughly twenty bug fixes. The release bumps its Kubernetes libraries to 1.36.2 and pulls in a golang/net security fix.
+
+**Source:** [Gatekeeper v3.23.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.23.0) - July 9, 2026
+
+---
+
+## Argo CD 3.4.5 fixes an auto-sync regression that skipped commits during manifest generation
+
+Argo CD published [v3.4.5](https://github.com/argoproj/argo-cd/releases/tag/v3.4.5) on July 9, a cherry-pick patch for the 3.4 line. The headline fix addresses auto-sync being skipped when a newer commit arrives mid-sync while `manifest-generate-paths` is in use — a case that could silently leave an application out of sync with its Git source.
+
+The release also stops the repo-server from honoring the primary source's depth instead of a referenced source's, avoids running an auth reconcile during server-side apply, corrects deleted resources being shown in the UI, prevents `replace` operations from clobbering non-ignored fields, and fixes a regression in Dex config environment-variable substitution. It bumps `golang.org/x/crypto` to 0.53.0 and the Ubuntu base image to 26.04.
+
+**Source:** [Argo CD v3.4.5](https://github.com/argoproj/argo-cd/releases/tag/v3.4.5) - July 9, 2026
+
+---
+
+## containerd ships coordinated bugfix patches across all four supported release branches
+
+containerd released [1.7.34](https://github.com/containerd/containerd/releases/tag/v1.7.34), [2.0.11](https://github.com/containerd/containerd/releases/tag/v2.0.11), [2.2.6](https://github.com/containerd/containerd/releases/tag/v2.2.6), and [2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3) together across July 9 and 10, covering every currently supported release branch. These are maintenance releases, not security fixes.
+
+The changes concentrate on CRI and sandbox lifecycle stability: fixes for lost container exit events that arrive before container info is cached, a nil-pointer path during NRI IP lookup, rejecting container creation when the sandbox is not running, and cleaning up sandboxes correctly when a hook fails. Because the runtime underpins most Kubernetes nodes, clusters hitting stuck-container or sandbox-cleanup edge cases are the ones that should schedule the patch.
+
+**Source:** [containerd 2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3) - July 9, 2026
+
+---


### PR DESCRIPTION
## Summary

Five primary-source releases landed across the cloud native control plane in the last 24 hours, making for an active patch-and-release day rather than a quiet one. The digest leads with cert-manager 1.21.0 — a feature release (ACME Renewal Information, AWS IAM auth for the Vault issuer) that also carries three Helm-chart breaking changes operators must handle before upgrading. It is joined by CoreDNS 1.14.5 (DoH/DoH3 transport hardening plus DoH upstreams in the forward plugin), OPA Gatekeeper 3.23.0 (mutation operation scoping, remote-cluster status routing), an Argo CD 3.4.5 fix for a silent auto-sync regression, and a coordinated containerd bugfix wave across all four supported branches. Every item was verified against its release notes or advisory; two otherwise-eligible items were cut on failed verification (see below).

## Run metadata

- Run time: `2026-07-10 06:00 Europe/London`
- Coverage window: `2026-07-09 06:00 Europe/London` to `2026-07-10 06:00 Europe/London`
- Source URLs inspected: `~48`
- Candidates longlisted: `~15`
- Candidates shortlisted: `7`
- Segments shipped: `5`
- Time horizon: last 24 hours only

## Segments

- cert-manager 1.21.0 - ACME Renewal Information (ARI) + Vault AWS IAM auth, plus default-RBAC breaking changes to plan for
- CoreDNS 1.14.5 - sanitizes DoH/DoH3 parse errors, bounds DoQ reads, adds DoH upstreams to the forward plugin
- OPA Gatekeeper 3.23.0 - `operations` scoping on mutation `ApplyTo` and remote-cluster status routing
- Argo CD 3.4.5 - fixes auto-sync silently skipping commits during `manifest-generate-paths` generation
- containerd patch wave - coordinated 1.7.34 / 2.0.11 / 2.2.6 / 2.3.3 CRI and sandbox-lifecycle bugfixes (not security)

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| cert-manager 1.21.0 published July 9; adds ARI (RFC 9773) behind `ACMEUseARI`, Vault AWS IAM auth, `renewalPolicies` | [Release notes](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0) + [official 1.21 notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.21/) | ✅ |
| cert-manager Helm breaking changes: tokenrequest RBAC removed, `cert-manager-edit` drops create on Challenges/Orders, metrics values removed / port renamed to `http-metrics` | [official 1.21 notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.21/) | ✅ |
| DNS01 solver-bypass advisory GHSA-8rvj-mm4h-c258 (High, CVSS 7.3) fixed in 1.19.6/1.20.3 (referenced as prior hardening, not new) | [Advisory](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258) | ✅ |
| CoreDNS 1.14.5 published July 10; sanitizes DoH/DoH3 parse errors, Go TLS defaults, bounds DoQ stream reads; forward plugin gains DoH + per-upstream timeout; dnstap reliability fixes | [Release](https://github.com/coredns/coredns/releases/tag/v1.14.5) | ✅ |
| Gatekeeper 3.23.0 published July 9; adds `operations` to mutation `ApplyTo`, remote-cluster status routing, structured logging, oras-go v2, K8s libs 1.36.2 | [Release](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.23.0) | ✅ |
| Argo CD 3.4.5 published July 9; fixes auto-sync skipped when newer commit arrives during `manifest-generate-paths` (#27875, cherry-pick #28227) plus five other fixes; x/crypto 0.53.0, Ubuntu 26.04 | [Release / changelog](https://github.com/argoproj/argo-cd/releases/tag/v3.4.5) | ✅ |
| containerd 1.7.34 / 2.0.11 / 2.2.6 / 2.3.3 released July 9–10 as coordinated maintenance (not security); CRI + sandbox-lifecycle fixes | [2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3), [1.7.34](https://github.com/containerd/containerd/releases/tag/v1.7.34) (timestamps from releases.atom) | ✅ |

## Items considered and dropped

- Kyverno 1.18.2 (July 10) - a namespace-boundary security backport was reported during research, but the advisory ID that surfaced (GHSA-79gf-7frw-68m9) returned 404 and could not be verified against a primary source. Cut rather than cite an unverifiable advisory.
- Prometheus 3.5.5 (July 9) - the specific CVE tied to the `sanitize-html` UI-dependency bump (reported as CVE-2026-53606) did not appear in Prometheus's advisories; the remaining UI dependency bump was too thin to ship alone.
- Helm 4.2.3 / 3.21.3 (July 9) - single `golang.org/x/crypto` bump, no notable change.
- Talos v1.13.6 (July 9) - routine kernel (6.18.38) and Go toolchain bump.
- vLLM v0.25.0rc1–rc3 (July 8–9) - pre-release candidates, iterative bugfixes, not a GA.
- etcd v3.7.0, OTel Collector v0.156.0, Karpenter patch wave, NCCL v2.30.7-1 - published July 7–8, outside the 24-hour window.
- arXiv systems preprints (July 9–10, e.g. non-GPU accelerator limits for MoE/multimodal serving on Ascend; session-centric LLM scheduling) - relevant but single unreviewed preprints with low immediate actionability; held for possible human review.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~15 in-window; 7 shortlisted
- Segments shipped: 5
- Any unresolved framing concerns: cert-manager's RBAC tightening is framed as follow-up hardening to the earlier (already-fixed) DNS01 solver advisory, not as a new vulnerability disclosure.
- Any vendor-attributed claims: none — all segments cite OSS project release notes or security advisories.
- No AI/HPC segment this window: the only fresh serving-stack releases were vLLM pre-release candidates; not shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmq7gTNt2MHMvqet74vp5u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cmq7gTNt2MHMvqet74vp5u)_