### PR TITLE
Rawkode Academy News - July 11, 2026

### DIFF
--- a/content/news/2026-07-11-sglang-prometheus-kyverno/index.mdx
+++ b/content/news/2026-07-11-sglang-prometheus-kyverno/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "SGLang 0.5.15 tunes GLM-5.2 for Blackwell, Prometheus patches an LTS range-query bug, Kyverno fixes admission validation"
+description: "SGLang 0.5.15 ships production GLM-5.2 serving on B300 with a faster speculative-decoding path, Prometheus 3.13.1 fixes a TSDB cache bug that corrupted range queries on the LTS line, and Kyverno 1.18.2 stops policies from skipping required image validation."
+publishedAt: 2026-07-11
+authors:
+  - rawkode
+technologies:
+  - prometheus
+  - kyverno
+  - ai-infrastructure
+---
+
+Three primary-source releases landed in the last day across AI serving, metrics, and policy. It was a fairly quiet window, so this is a tight three-item digest rather than a padded one.
+
+## SGLang 0.5.15 ships production GLM-5.2 serving and a faster speculative-decoding path
+
+SGLang published [v0.5.15](https://github.com/sgl-project/sglang/releases/tag/v0.5.15) on July 10, focused on serving GLM-5.2 in NVFP4 on Blackwell hardware and cutting speculative-decoding overhead. The project reports GLM-5.2 NVFP4 running at 500+ tokens/sec per user on 8x B300, and 450 on 4x GB300 at batch size 1.
+
+The release makes Spec V2 the tuned path: zero-overhead scheduling via a CUDA-graphable DSA draft-extend that drops device-host syncs and fuses metadata ops, which SGLang measures at +11% end-to-end throughput. Two supporting kernels land alongside it — IndexShare MTP reuses the indexer top-k across draft steps for up to 1.9x lower draft-step cost at long context, and TopK V2 fuses top-k selection with the page-table transform and supports runtime k up to 2048. Day-0 model support arrives for Hunyuan 3, HRM-Text, NVIDIA LocateAnything-3B, Baidu Unlimited-OCR, and Qwen3.6 in mixed NVFP4, plus a FlashKDA prefill backend for KDA linear attention and a built-in `web_search` tool backed by Exa.
+
+Every throughput figure here is SGLang's own benchmark; treat them as project-reported until independently reproduced.
+
+**Source:** [SGLang v0.5.15 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.15) - July 10, 2026
+
+---
+
+## Prometheus 3.13.1 fixes a TSDB cache bug that returned wrong samples to range queries
+
+Prometheus released [v3.13.1](https://github.com/prometheus/prometheus/releases/tag/v3.13.1) on July 10, a single-bugfix patch for the 3.13 LTS line. The fix targets a TSDB head-chunk cache that could return samples from the wrong chunk, or spurious not-found errors, for range queries issued after a head-chunk truncation (#19134).
+
+Head-chunk truncation runs continuously as the head block advances, so any range query spanning a truncation boundary could read incorrect data or fail rather than error loudly. Teams running 3.13.0 LTS in production should treat this as a data-correctness patch rather than an optional update, particularly where range queries back alerting or dashboards.
+
+**Source:** [Prometheus v3.13.1 release](https://github.com/prometheus/prometheus/releases/tag/v3.13.1) - July 10, 2026
+
+---
+
+## Kyverno 1.18.2 stops policies from skipping required image validation
+
+Kyverno cut [v1.18.2](https://github.com/kyverno/kyverno/releases/tag/v1.18.2) on July 10, led by a fix that stops the engine from aborting a required validation rule when an image reference does not match. Before the patch, a non-matching image in an image-scoped rule could short-circuit validation that operators intended to enforce, letting a workload through unchecked.
+
+The release also restarts dynamic watchers in background reporting when the API server returns HTTP 410 Gone, so policy reports recover after resource-version expiry instead of going stale, and backports a namespace-boundary enforcement fix in the generate controller. On the tooling side, the CLI now accepts multiple CRDs in a single `--crd-path` file, and the Pod Security Standards Helm chart tightens its allowed volume-type set.
+
+**Source:** [Kyverno v1.18.2 release](https://github.com/kyverno/kyverno/releases/tag/v1.18.2) - July 10, 2026
+
+---

--- a/content/news/2026-07-11-sglang-prometheus-kyverno/index.mdx
+++ b/content/news/2026-07-11-sglang-prometheus-kyverno/index.mdx
@@ -7,7 +7,6 @@ authors:
 technologies:
   - prometheus
   - kyverno
-  - ai-infrastructure
 ---
 
 Three primary-source releases landed in the last day across AI serving, metrics, and policy. It was a fairly quiet window, so this is a tight three-item digest rather than a padded one.


### PR DESCRIPTION
## Summary

A tight three-item digest from a fairly quiet 24-hour window. All three are primary-source project releases from July 10: SGLang 0.5.15 (production GLM-5.2 serving on Blackwell plus a faster speculative-decoding path), Prometheus 3.13.1 (a data-correctness patch for the 3.13 LTS TSDB), and Kyverno 1.18.2 (an admission-validation correctness fix). Nothing else in the window cleared the bar without padding, so the digest ships three rather than six.

## Run metadata

- Run time: `2026-07-11 06:00 Europe/London`
- Coverage window: `2026-07-10 05:00 UTC` to `2026-07-11 05:00 UTC` (06:00 BST run; previous-day UTC releases)
- Source URLs inspected: `~23`
- Candidates longlisted: `10`
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- SGLang 0.5.15 ships production GLM-5.2 serving and a faster speculative-decoding path — core AI/HPC serving audience; concrete kernel changes and project-reported Blackwell throughput.
- Prometheus 3.13.1 fixes a TSDB cache bug that returned wrong samples to range queries — data-correctness patch on the LTS line that operators should apply, not defer.
- Kyverno 1.18.2 stops policies from skipping required image validation — admission-control correctness fix where a non-matching image could short-circuit an intended validation.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| SGLang v0.5.15 released July 10, 2026 | [SGLang v0.5.15 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.15) — release timestamp | ✅ |
| GLM-5.2 NVFP4 at 500+ tok/s/user on 8x B300, 450 on 4x GB300 (bs=1); framed as project-reported | SGLang v0.5.15 release notes — highlights | ✅ |
| Spec V2 +11% end-to-end TPS; IndexShare MTP up to 1.9x lower draft-step cost; TopK V2 runtime k up to 2048 | SGLang v0.5.15 release notes — highlights | ✅ |
| Day-0 models (Hunyuan 3, HRM-Text, LocateAnything-3B, Unlimited-OCR, Qwen3.6 NVFP4); FlashKDA + Exa web_search | SGLang v0.5.15 release notes | ✅ |
| Prometheus v3.13.1 released July 10, 2026 as a 3.13 LTS bugfix | [Prometheus v3.13.1 release](https://github.com/prometheus/prometheus/releases/tag/v3.13.1) | ✅ |
| Fix: TSDB head-chunk cache returned wrong-chunk samples / spurious not-found errors on range queries after head-chunk truncation (#19134) | Prometheus v3.13.1 changelog | ✅ |
| Kyverno v1.18.2 released July 10, 2026 | [Kyverno v1.18.2 release](https://github.com/kyverno/kyverno/releases/tag/v1.18.2) | ✅ |
| Fix: do not abort required validation on non-matching images; dynamic-watcher restart on 410; namespace-boundary hardening in generate controller; CLI multi-CRD `--crd-path`; PSS Helm volume-types | Kyverno v1.18.2 release notes | ✅ |

## Items considered and dropped

- containerd 2.3.3 + 2.2.6 / 2.0.11 / 1.7.34 (Jul 9 23:41 – Jul 10 00:04 UTC) — coordinated patch wave, but bulk of it lands before the window start and it carries no CVEs; routine stability hygiene.
- etcd v3.7.0 (Jul 8), Kubernetes v1.37.0-alpha.3 (Jul 8), Argo CD v3.4.5 (Jul 9), OpenTelemetry Collector v0.156.0 (Jul 7), Flux v2.9.1 (Jul 7), Talos v1.13.6 (Jul 9), cert-manager v1.21.0 (Jul 8) — all outside the 24-hour window.
- arXiv cs.DC July 10 papers (SMetric session-centric LLM scheduling; GPU frequency under ML workloads; limits of non-GPU accelerators) — relevant but early-stage academic work; not deep-read enough to fact-check to the standard the digest requires.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial Review → Fact-check → Edit Pass → Final Review.
- Total candidates considered: 10; segments shipped: 3.
- Freshness note: SGLang and Prometheus fall cleanly inside the rolling window; Kyverno released at 02:34 UTC on July 10, ~2.5h before a strict 05:00 UTC start but well within the previous UTC day, consistent with how prior digests (e.g. 2026-06-20) treated same-prior-day releases. Flagged here for transparency.
- Vendor-attributed claims: all SGLang throughput figures are the project's own benchmarks and are labelled as project-reported in the segment; no independent corroboration was available at publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01916rGuPFcsdSbJ1rtnoR72

---
_Generated by [Claude Code](https://claude.ai/code/session_01916rGuPFcsdSbJ1rtnoR72)_