### PR TITLE
Rawkode Academy News - August 8, 2026

### DIFF
--- a/content/news/2026-08-08-sglang-argocd-flux/index.mdx
+++ b/content/news/2026-08-08-sglang-argocd-flux/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "SGLang 0.5.17 ships Kimi K3 support, Argo CD 3.5 promotes impersonation, Flux 2.9.4 hardens supply-chain paths"
+description: "SGLang 0.5.17 adds day-zero Kimi K3 support and a Rust ingress frontend, Argo CD 3.5.0 moves Source Hydrator and impersonation to beta on Helm 4, and Flux 2.9.4 tightens Git and OCI verification across its controllers."
+publishedAt: 2026-08-08
+authors:
+  - rawkode
+technologies:
+  - argo
+  - fluxcd
+  - kubernetes
+---
+
+Three primary-source releases landed in the last 24 hours across inference serving and GitOps. Two are feature minors, one is a hardening patch, so this is a short, focused digest rather than a padded one.
+
+## SGLang 0.5.17 adds day-zero Kimi K3 support and a Rust ingress frontend
+
+The inference-serving project released [SGLang v0.5.17](https://github.com/sgl-project/sglang/releases/tag/v0.5.17) on August 8, rolling up 582 pull requests from 194 contributors. The headline is day-zero support for Kimi K3, a 2.8T-parameter mixture-of-experts model that routes the top 16 of 896 experts through a 3584-dimension latent space with native MXFP4 quantization. The release also adds MiniMax-H3 and the EmbeddingGemma and LFM2.5 embedding models.
+
+Two infrastructure changes matter for operators. An initial Rust frontend moves network ingress and tokenization off the Python path onto a multi-threaded implementation, addressing a common CPU bottleneck ahead of the GPU. Distributed Weight Data Parallelism (DWDP) for MoE prefill is new: SGLang reports a 1.92x gain over DEP4 on 4x B200 serving gpt-oss-120b, and 506K versus 329K tok/s (1.54x) at saturation on its own benchmark.
+
+Plan for breaking changes before upgrading: the `sglang.jit_kernel` module is deprecated in favour of `sglang.kernels`, breakable prefill CUDA graphs are now on by default for DP attention, multimodal request errors return HTTP 400 instead of 500, and the helion dependency jumps from 0.2.6 to 1.4.
+
+**Source:** [SGLang v0.5.17 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.17) - August 8, 2026
+
+---
+
+## Argo CD 3.5.0 promotes Source Hydrator and impersonation to beta, moves to Helm 4
+
+Argo CD published [v3.5.0](https://github.com/argoproj/argo-cd/releases/tag/v3.5.0) on August 7, a stable minor with roughly 335 commits since the previous release. Source Hydrator and application-level impersonation both graduate from alpha to beta. Impersonation lets sync operations run under user-scoped credentials rather than the application controller's service account, which is the change multi-tenant platform teams have been waiting on for tighter per-team blast-radius control.
+
+The release also carries structural upgrades: the build migrates from Helm 3 to Helm 4, the UI moves to React 19 (existing UI extensions will need updates), repo-server gains mTLS, ApplicationSet picks up concurrency controls when reconciling managed applications, and the network view adds Gateway API resources. Azure DevOps repositories can now authenticate with an Azure Service Principal.
+
+**Source:** [Argo CD v3.5.0 release](https://github.com/argoproj/argo-cd/releases/tag/v3.5.0) - August 7, 2026
+
+---
+
+## Flux 2.9.4 hardens Git and OCI supply-chain paths across its controllers
+
+Sidecar-free GitOps toolkit Flux shipped [v2.9.4](https://github.com/fluxcd/flux2/releases/tag/v2.9.4) on August 7, a patch that bundles several security-boundary fixes rather than emergency CVE remediation. The image-automation-controller now validates refspecs to block force-updates and deletions, source-controller pins OCI chart digests during verification and restricts GCS authentication to service-account keys, and source-watcher enforces tarball extraction and glob-expansion limits.
+
+Component versions bump to source-controller v1.9.4, source-watcher v2.2.3, notification-controller v1.9.3, and image-reflector- and image-automation-controller v1.2.4. The release requires CRD schema updates for `ArtifactGenerator` and `ImageUpdateAutomation`, and `flux migrate -f` now targets version 2.9, so apply the updated CRDs before upgrading the controllers.
+
+**Source:** [Flux v2.9.4 release](https://github.com/fluxcd/flux2/releases/tag/v2.9.4) - August 7, 2026
+
+---


### PR DESCRIPTION
## Summary

Three primary-source releases landed inside the last-24-hours coverage window, spanning inference serving and GitOps: SGLang 0.5.17 (day-zero Kimi K3 support plus a Rust ingress frontend and a new MoE-prefill parallelism strategy), Argo CD 3.5.0 (Source Hydrator and impersonation to beta, Helm 4, React 19), and Flux 2.9.4 (Git/OCI supply-chain hardening across its controllers, with required CRD schema updates). It was a quiet window with no other eligible primary releases, so this ships as a tight three-segment digest rather than a padded one.

## Run metadata

- Run time: `2026-08-08 06:21 Europe/London`
- Coverage window: `2026-08-07 05:21 UTC` to `2026-08-08 05:21 UTC`
- Source URLs inspected: `~28` (GitHub release atom feeds + CNCF/Kubernetes blogs + search)
- Candidates longlisted: `6`
- Candidates shortlisted: `4`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- SGLang 0.5.17 adds day-zero Kimi K3 support and a Rust ingress frontend - new MoE-prefill parallelism and a Python-to-Rust ingress move change serving throughput and CPU-side bottlenecks.
- Argo CD 3.5.0 promotes Source Hydrator and impersonation to beta, moves to Helm 4 - impersonation lets sync run under user-scoped credentials, tightening multi-tenant blast radius.
- Flux 2.9.4 hardens Git and OCI supply-chain paths across its controllers - refspec validation, OCI digest pinning, and required CRD schema updates are operator action items.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| SGLang v0.5.17 published Aug 8, 2026 (582 PRs, 194 contributors) | [releases.atom `<updated>` 2026-08-08T01:43:39Z](https://github.com/sgl-project/sglang/releases/tag/v0.5.17) | ✅ |
| Kimi K3 day-zero support: 2.8T params, top-16 of 896 experts, 3584-dim latent, MXFP4 | [SGLang v0.5.17 release notes](https://github.com/sgl-project/sglang/releases/tag/v0.5.17) | ✅ |
| DWDP MoE prefill: project reports 1.92x over DEP4 on 4x B200 (gpt-oss-120b); 506K vs 329K tok/s at saturation | [SGLang v0.5.17 release notes, performance section](https://github.com/sgl-project/sglang/releases/tag/v0.5.17) | ✅ (project-attributed benchmark) |
| SGLang breaking changes: jit_kernel→kernels, multimodal errors HTTP 400, helion 0.2.6→1.4 | [SGLang v0.5.17 release notes, breaking changes](https://github.com/sgl-project/sglang/releases/tag/v0.5.17) | ✅ |
| Argo CD v3.5.0 published Aug 7, 2026 (stable minor) | [releases.atom `<updated>` 2026-08-07T15:56:38Z](https://github.com/argoproj/argo-cd/releases/tag/v3.5.0) | ✅ |
| Source Hydrator + impersonation to beta; Helm 4; React 19; repo-server mTLS; Gateway API in network view | [Argo CD v3.5.0 release notes](https://github.com/argoproj/argo-cd/releases/tag/v3.5.0) | ✅ |
| Flux v2.9.4 published Aug 7, 2026; routine patch, no CVEs | [releases.atom `<updated>` 2026-08-07T14:32:26Z](https://github.com/fluxcd/flux2/releases/tag/v2.9.4) | ✅ |
| refspec validation (image-automation), OCI digest pinning + GCS SA-key auth (source-controller), controller version bumps, CRD updates for ArtifactGenerator/ImageUpdateAutomation | [Flux v2.9.4 release notes](https://github.com/fluxcd/flux2/releases/tag/v2.9.4) | ✅ |

## Items considered and dropped

- vLLM v0.27.0rc1 - primary source timestamped 2026-08-07T00:36:54Z, ~28h old at run time and thus just outside the strict 24h window; also a release candidate rather than a GA. Held for a future run if promoted to stable in-window.
- CNCF blog "Does Kubernetes DRA Replace HAMi?" (Aug 7) - maintainer opinion/comparison post, not a primary release or project change; fails the "news, not takes" rule.
- CNCF blog "Shadow AI in CI/CD" (Aug 7) - member post, positioning/threat-modeling commentary without a concrete technical artifact.
- Kubernetes v1.37.0-rc.0, containerd API 1.12.0-beta.0, cosign 3.1.3, OTel Collector Contrib 0.158.0, KServe 0.20.0, Dapr 1.17.12/1.16.18 - all real primary releases but timestamped Aug 4-6, outside the 24h window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 6 longlisted (plus ~20 projects whose latest release fell outside the window)
- Segments shipped: 3
- Any unresolved framing concerns: none. Flux 2.9.4 is the weakest of the three (a patch) but carries security-boundary behavior changes and required CRD updates that are genuine operator action items, so it clears the substance bar.
- Any vendor-attributed claims: the SGLang DWDP throughput numbers are the project's own reported benchmark and are attributed as such in the segment; no independent corroboration was available at run time.
- Note on schema: this repo's `news` collection uses `authors`/`technologies` frontmatter (not `tags`/`draft`) and stores each item at `content/news/{slug}/index.mdx`, so the file follows the repo's actual Zod schema rather than the generic template in the agent spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX7p6YVWAsnVPJPMTbvWhu)_