### PR TITLE
Rawkode Academy News - August 11, 2026

### DIFF
--- a/content/news/2026-08-11-vllm-0-27-containerd-2-4-nccl/index.mdx
+++ b/content/news/2026-08-11-vllm-0-27-containerd-2-4-nccl/index.mdx
@@ -5,8 +5,8 @@ publishedAt: 2026-08-11
 authors:
   - rawkode
 technologies:
-  - ai-infrastructure
   - containerd
+  - kubernetes
 ---
 
 Three primary-source releases landed in the last 24 hours across inference serving, container runtimes, and GPU collective communication. It was an otherwise quiet window, so this is a focused digest rather than a padded one.

--- a/content/news/2026-08-11-vllm-0-27-containerd-2-4-nccl/index.mdx
+++ b/content/news/2026-08-11-vllm-0-27-containerd-2-4-nccl/index.mdx
@@ -1,0 +1,46 @@
+---
+title: "vLLM 0.27.0 lands, containerd opens the 2.4 line, NCCL adds Compute Fabric Transport"
+description: "vLLM cut 0.27.0 with a PyTorch 2.13 base and expanded model support, containerd published the first 2.4.0 beta with an EROFS warm image cache, and NCCL 2.31.2 introduced Compute Fabric Transport APIs for Blackwell."
+publishedAt: 2026-08-11
+authors:
+  - rawkode
+technologies:
+  - ai-infrastructure
+  - containerd
+---
+
+Three primary-source releases landed in the last 24 hours across inference serving, container runtimes, and GPU collective communication. It was an otherwise quiet window, so this is a focused digest rather than a padded one.
+
+## vLLM 0.27.0 moves to a PyTorch 2.13 base and widens model and hardware support
+
+vLLM published [v0.27.0](https://github.com/vllm-project/vllm/releases/tag/v0.27.0) on August 10, rolling up 561 commits from 242 contributors. The release rebases the runtime onto PyTorch 2.13.0 with torchvision 0.28.0 and Triton 3.7.1, and adds model support for Kimi K3, Qwen3.5 dense and MoE variants, and DeepSeek-V4.
+
+On the engine side, Model Runner V2 extends beyond generative decoding to non-generative workloads including encoder-only attention, and the release adds a simplified fault-tolerance framework for combined data- and expert-parallel (DP+EP) serving plus NIXL-based prefill/decode disaggregation for hybrid MLA+SSM models. FlashAttention 4 integration deepens on SM100 with FP8 KV cache, and the notes list early enablement for NVIDIA Rubin (`sm_107`) alongside AMD `gfx1250`.
+
+The DP+EP fault-tolerance work and the encoder path in Model Runner V2 are the parts worth testing for teams running large-scale or mixed-workload inference rather than single-model decode.
+
+**Source:** [vLLM v0.27.0 release](https://github.com/vllm-project/vllm/releases/tag/v0.27.0) - August 10, 2026
+
+---
+
+## containerd cuts the first 2.4.0 beta with an EROFS warm image cache
+
+The containerd project published [v2.4.0-beta.0](https://github.com/containerd/containerd/releases/tag/v2.4.0-beta.0) on August 10, opening the 2.4 release line ahead of a tentative GA on August 26 per the project's [release schedule](https://github.com/containerd/containerd/blob/main/RELEASES.md). Unlike 2.3, which is the current LTS branch supported through April 2028, 2.4 is a standard release and may carry breaking changes.
+
+The beta adds a warm image cache for the EROFS snapshotter and extends CRI runtime introspection so OCI runtime features can be surfaced for non-runc implementations. Other changes include a media type in the content create event and maximum-size labeling for snapshots. As a pre-release with functionality still under development, it is a testing target, not a production upgrade.
+
+**Source:** [containerd v2.4.0-beta.0 release](https://github.com/containerd/containerd/releases/tag/v2.4.0-beta.0) - August 10, 2026
+
+---
+
+## NCCL 2.31.2 adds Compute Fabric Transport and per-collective tuning
+
+NVIDIA released [NCCL v2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1) on August 11. The headline addition is Compute Fabric Transport (CFT): host and device APIs for registering window memory with CUDA logical endpoints and issuing device-side Put, Get, and NVLS operations. The release notes state CFT is supported on Blackwell GPUs with CUDA Toolkit 13.3 or later.
+
+The release also introduces per-collective configuration and tuning through a new `ncclCollConfig_t` type, with algorithm selection and CTA overrides at the call site rather than only through global environment variables. It extends GPU-Initiated Networking (GIN) with an EFA GDA backend and device-side timeouts, improves the Parallel Aggregated Tree algorithm for ReduceScatter and AllGather, and ships a Profiler v7 that exposes per-kernel phase events, plus fixes for hangs, data corruption, and resource leaks.
+
+Per-collective tuning matters for workloads that mix communication patterns in one job, where a single global algorithm choice previously forced a compromise.
+
+**Source:** [NVIDIA NCCL v2.31.2-1 release](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1) - August 11, 2026
+
+---


### PR DESCRIPTION
## Summary

Three primary-source releases landed within the last 24 hours across inference serving, container runtimes, and GPU collective communication: vLLM 0.27.0, containerd 2.4.0-beta.0, and NCCL v2.31.2-1. Each opens a concrete, testable change for AI/HPC and platform practitioners, so all three made the cut. The window was otherwise quiet; this is a focused three-segment digest rather than a padded one.

## Run metadata

- Run time: `2026-08-11 06:00 Europe/London`
- Coverage window: `2026-08-10 06:00 BST` to `2026-08-11 06:00 BST`
- Source URLs inspected: `~38`
- Candidates longlisted: `4`
- Candidates shortlisted: `3`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- vLLM 0.27.0 lands - PyTorch 2.13 base, DP+EP fault tolerance, and Model Runner V2 non-generative support change what large-scale inference deployments can test.
- containerd opens the 2.4 line - first 2.4.0 beta adds an EROFS warm image cache and CRI runtime-feature introspection for non-runc runtimes ahead of a tentative Aug 26 GA.
- NCCL 2.31.2 adds Compute Fabric Transport - device-side Put/Get/NVLS APIs on Blackwell plus per-collective tuning via `ncclCollConfig_t`.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| vLLM v0.27.0 published Aug 10, 2026 (561 commits, 242 contributors) | [vLLM releases/tag/v0.27.0](https://github.com/vllm-project/vllm/releases/tag/v0.27.0) - release header | ✅ |
| vLLM rebases on PyTorch 2.13.0, torchvision 0.28.0, Triton 3.7.1 | [vLLM v0.27.0](https://github.com/vllm-project/vllm/releases/tag/v0.27.0) - Highlights/Dependencies | ✅ |
| vLLM adds Kimi K3, Qwen3.5, DeepSeek-V4 support; Model Runner V2 non-generative; DP+EP fault tolerance; SM100 FA4 FP8 KV; sm_107/gfx1250 | [vLLM v0.27.0](https://github.com/vllm-project/vllm/releases/tag/v0.27.0) - Highlights | ✅ |
| containerd v2.4.0-beta.0 published Aug 10, 2026 | [containerd releases/tag/v2.4.0-beta.0](https://github.com/containerd/containerd/releases/tag/v2.4.0-beta.0) - release header | ✅ |
| 2.4 is a non-LTS line, tentative GA Aug 26, 2026; 2.3 is LTS through Apr 2028 | [containerd RELEASES.md](https://github.com/containerd/containerd/blob/main/RELEASES.md) - release table | ✅ |
| beta adds EROFS snapshotter warm image cache and CRI OCI runtime feature introspection for non-runc runtimes | [containerd v2.4.0-beta.0](https://github.com/containerd/containerd/releases/tag/v2.4.0-beta.0) - changelog | ✅ |
| NCCL v2.31.2-1 published Aug 11, 2026 | [NCCL releases/tag/v2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1) - release header | ✅ |
| CFT host/device APIs (window memory, device Put/Get/NVLS); supported on Blackwell + CUDA Toolkit 13.3+ | [NCCL v2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1) - release notes | ✅ |
| Per-collective config via `ncclCollConfig_t`; GIN EFA GDA backend; PAT ReduceScatter/AllGather; Profiler v7 | [NCCL v2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1) - release notes | ✅ |

## Items considered and dropped

- Kargo v1.11.1 (Aug 10) - patch release of nine backported fixes and UI tweaks; below the technical-substance floor for a standalone segment.
- CNCF KubeCon + CloudNativeCon NA 2026 schedule (Aug 10) - conference/marketing announcement, no technical artifact; out of scope.
- arXiv cs.DC systems preprints (Aug 10-11: FlashBoot, OasisKV, ElastiCo, etc.) - relevant to the AI/HPC audience but low actionability as day-one preprints; held for possible deeper treatment rather than a news blurb.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 4 in-window releases plus a set of arXiv preprints; ~38 primary-source URLs inspected across CNCF, Kubernetes, service mesh, GitOps, observability, security, Wasm, and AI/HPC projects.
- Segments shipped: 3
- Any unresolved framing concerns: The containerd and NCCL items are a beta and a point release respectively; both are framed as testing targets, not production upgrades. vLLM performance claims were deliberately left out and only feature/version facts retained.
- Any vendor-attributed claims: NCCL CFT hardware/toolkit support (Blackwell, CUDA 13.3+) is attributed to NVIDIA's release notes; no independent benchmark claims are made.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsqYmF4dQCnk3rUgv3qyez)_