### PR TITLE
Rawkode Academy News - August 13, 2026

### DIFF
--- a/content/news/2026-08-13-containerd-kueue-argo-cd-vllm/index.mdx
+++ b/content/news/2026-08-13-containerd-kueue-argo-cd-vllm/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "containerd disables CRI checkpoint restore by default, Kueue locks LWS group size, Argo CD hardens Secret masking"
+title: "containerd disables CRI checkpoint restore by default, Kueue locks LWS group size, Argo CD hardens Secret masking, vLLM adds day-0 Qwen3.8 serving"
 description: "containerd 2.3.4 and 2.2.7 flip CRI checkpoint restore in CreateContainer off by default, Kueue 0.19.1 makes LeaderWorkerSet group size immutable to close a quota bypass, Argo CD backports Secret-masking fixes across three minors, and vLLM adds day-0 serving for the 2.4T-parameter Qwen3.8 MoE."
 publishedAt: 2026-08-13
 authors:
@@ -8,7 +8,6 @@ technologies:
   - containerd
   - kueue
   - argo
-  - ai-infrastructure
 ---
 
 Four primary-source releases landed in the last 24 hours across container runtimes, batch scheduling, GitOps, and AI serving.

--- a/content/news/2026-08-13-containerd-kueue-argo-cd-vllm/index.mdx
+++ b/content/news/2026-08-13-containerd-kueue-argo-cd-vllm/index.mdx
@@ -1,0 +1,62 @@
+---
+title: "containerd disables CRI checkpoint restore by default, Kueue locks LWS group size, Argo CD hardens Secret masking"
+description: "containerd 2.3.4 and 2.2.7 flip CRI checkpoint restore in CreateContainer off by default, Kueue 0.19.1 makes LeaderWorkerSet group size immutable to close a quota bypass, Argo CD backports Secret-masking fixes across three minors, and vLLM adds day-0 serving for the 2.4T-parameter Qwen3.8 MoE."
+publishedAt: 2026-08-13
+authors:
+  - rawkode
+technologies:
+  - containerd
+  - kueue
+  - argo
+  - ai-infrastructure
+---
+
+Four primary-source releases landed in the last 24 hours across container runtimes, batch scheduling, GitOps, and AI serving.
+
+## containerd 2.3.4 and 2.2.7 disable CRI checkpoint restore in CreateContainer by default
+
+The containerd project published [v2.3.4](https://github.com/containerd/containerd/releases/tag/v2.3.4) and a sibling [v2.2.7](https://github.com/containerd/containerd/releases/tag/v2.2.7) backport on August 12, both flipping a CRI default and deprecating checkpoint restore through the `CreateContainer` path.
+
+Restore in `CreateContainer` is now disabled by default and requires the `enable_experimental_restore_via_create` option to turn back on; the codepaths are also disabled outright when CRIU is not installed, gated behind a new `enable_criu` option. Both releases set `runtimeFeatures.UserNamespacesHostNetwork` to true by default in CRI and enable OCI runtime feature introspection for non-runc runtimes. Bug fixes include a memory leak in the OOM watcher map when stopping container monitoring, shims orphaned on transient errors while loading process IDs, corruption of binary protobuf shim start responses caused by premature whitespace trimming, and the EROFS snapshotter dropping lower layers stacked above merged filesystem metadata.
+
+Teams that restore containers through the CRI `CreateContainer` path need to opt back in explicitly before upgrading either line.
+
+**Source:** [containerd v2.3.4 release](https://github.com/containerd/containerd/releases/tag/v2.3.4) - August 12, 2026
+
+---
+
+## Kueue 0.19.1 makes LeaderWorkerSet group size immutable to close a quota bypass
+
+Kueue shipped [v0.19.1](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.1), with a [v0.18.5](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.5) backport, on August 12. The release makes `spec.leaderWorkerTemplate.size` immutable while a LeaderWorkerSet is managed by Kueue, behind a new `LWSImmutableGroupSize` feature gate that is Beta and enabled by default.
+
+The immutability closes a quota bypass where raising the group size on an already-admitted, Kueue-managed LeaderWorkerSet ran more pods per group than the reserved quota covered. The release also tightens Topology Aware Scheduling validation: when `podSetSliceRequiredTopology` is set, `podSetSliceSize` must also be set and greater than zero, non-positive slice sizes are rejected, and `TASRecomputeAssignmentWithinSchedulingCycle` can no longer be enabled without `TopologyAwareScheduling`.
+
+Platform teams running gang-scheduled GPU jobs through LeaderWorkerSet should expect size edits to be rejected after upgrading and plan resize as recreate rather than in-place edit.
+
+**Source:** [Kueue v0.19.1 release](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.1) - August 12, 2026
+
+---
+
+## Argo CD backports Secret-masking hardening across 3.5, 3.4, and 3.3
+
+The Argo project released [v3.5.1](https://github.com/argoproj/argo-cd/releases/tag/v3.5.1), [v3.4.7](https://github.com/argoproj/argo-cd/releases/tag/v3.4.7), and [v3.3.14](https://github.com/argoproj/argo-cd/releases/tag/v3.3.14) on August 12, a coordinated patch train weighted toward Secret handling.
+
+The releases prevent server-side-diff CLI secret mask spoofing, reuse the server-side diff result when masking Secret data, and hide secrets in the `last-applied-configuration` annotation. They are labelled as bug fixes rather than a security advisory, and follow the earlier server-side-diff secret-extraction class of issue. The train also stops ApplicationSet progressive sync from reconciling in a tight loop, verifies terminating Applications against the API server, and treats `timeout.reconciliation=0` as disabled soft expiry.
+
+Operators running server-side diff should patch to keep Secret data from leaking through diff output or the applied-configuration annotation.
+
+**Source:** [Argo CD v3.5.1 release](https://github.com/argoproj/argo-cd/releases/tag/v3.5.1) - August 12, 2026
+
+---
+
+## vLLM adds day-0 serving for the 2.4T-parameter Qwen3.8 MoE
+
+vLLM published [day-0 support](https://vllm.ai/blog/2026-08-12-qwen3.8) for `Qwen/Qwen3.8-2.4T-A95B` on August 12, a 2.4-trillion-parameter sparse MoE that the project says runs out of the box with no architecture changes required.
+
+The model uses 512 experts across 92 layers with hybrid attention — full attention every fourth layer, linear attention elsewhere — and ships checkpoints in FP8, BF16, NVFP4, and MXFP4. vLLM reports it needs at least two NVIDIA B300 or AMD MI355X nodes, or a single node for the FP4-quantized version, and that the release adds kernels for the model's linear-attention, routing, and expert-parallel paths on both NVIDIA and AMD hardware.
+
+The serving path, not the weights, is the news here: same-day multi-vendor kernel support gives operators a concrete deployment target instead of waiting on downstream engine work.
+
+**Source:** [vLLM blog](https://vllm.ai/blog/2026-08-12-qwen3.8) - August 12, 2026
+
+---


### PR DESCRIPTION
## Summary

Four primary-source releases landed in the 24-hour window, all dated August 12, 2026, spanning container runtimes, batch scheduling, GitOps, and AI serving. Each is a real release with an operational consequence — a breaking runtime default, a beta gate that changes upgrade behaviour, a security-hardening backport train, and a same-day serving path — rather than positioning or commentary. Kubernetes core, service mesh, and CNCF governance were quiet in-window (nearest events fell on Aug 10–11 and were dropped).

## Run metadata

- Run time: `2026-08-13 06:00 Europe/London`
- Coverage window: `2026-08-12 05:00 UTC` to `2026-08-13 05:00 UTC`
- Source URLs inspected: `~45` (three domain sweeps + direct primary-source fact-checks)
- Candidates longlisted: `~15`
- Candidates shortlisted: `7`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- containerd 2.3.4 and 2.2.7 disable CRI checkpoint restore in CreateContainer by default - breaking default flip that CRI/checkpoint-restore operators must opt back into before upgrading either line.
- Kueue 0.19.1 makes LeaderWorkerSet group size immutable to close a quota bypass - `LWSImmutableGroupSize` beta gate is on by default, so gang-scheduled GPU teams must plan resize as recreate.
- Argo CD backports Secret-masking hardening across 3.5, 3.4, and 3.3 - coordinated same-day patch train closing Secret leakage through server-side diff and the applied-configuration annotation.
- vLLM adds day-0 serving for the 2.4T-parameter Qwen3.8 MoE - multi-vendor (NVIDIA B300 / AMD MI355X) kernels give operators an immediate deployment target for a large open-weight MoE.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Checkpoint restore in `CreateContainer` disabled by default + deprecated; disabled when CRIU absent; `enable_criu` added | [containerd v2.3.4 release notes](https://github.com/containerd/containerd/releases/tag/v2.3.4) | ✅ |
| `runtimeFeatures.UserNamespacesHostNetwork` defaults true; OCI feature introspection for non-runc runtimes; OOM-watcher/shim/EROFS fixes | [containerd v2.3.4 release notes](https://github.com/containerd/containerd/releases/tag/v2.3.4) | ✅ |
| Same checkpoint-restore change backported to the 2.2 line | [containerd v2.2.7 release](https://github.com/containerd/containerd/releases/tag/v2.2.7) | ✅ |
| `spec.leaderWorkerTemplate.size` immutable behind `LWSImmutableGroupSize` (Beta, on by default); closes quota bypass on admitted LWS | [Kueue v0.19.1 release notes](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.1) | ✅ |
| TAS: `podSetSliceSize` required and >0 when `podSetSliceRequiredTopology` set; `TASRecomputeAssignmentWithinSchedulingCycle` gated on `TopologyAwareScheduling` | [Kueue v0.19.1 release notes](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.1) | ✅ |
| SSD CLI secret mask spoofing prevented; server-side diff result reused when masking Secret data; secret hidden in `last-applied-configuration` annotation; bug fixes, no CVE label | [Argo CD v3.5.1 release notes](https://github.com/argoproj/argo-cd/releases/tag/v3.5.1) | ✅ |
| Coordinated same-day train v3.5.1 / v3.4.7 / v3.3.14 (Aug 12) | [v3.4.7](https://github.com/argoproj/argo-cd/releases/tag/v3.4.7), [v3.3.14](https://github.com/argoproj/argo-cd/releases/tag/v3.3.14) | ✅ |
| Day-0 vLLM support for `Qwen/Qwen3.8-2.4T-A95B`; 512 experts / 92 layers / hybrid attention; FP8/BF16/NVFP4/MXFP4; ≥2× B300 or MI355X (1 node for FP4); added linear-attention/routing/EP kernels on NVIDIA + AMD | [vLLM blog 2026-08-12](https://vllm.ai/blog/2026-08-12-qwen3.8) | ✅ |

## Items considered and dropped

- Cloud Native Buildpacks CNCF graduation - high value, but dated Aug 11 (out of the 24h window).
- CNCF blog "Building observable policy as code" (Kyverno + VictoriaMetrics), Aug 12 - editorial how-to, not an announcement or release artifact.
- CNCF blog "Advancing AI model interoperability with Docker and ModelPack", Aug 12 - editorial contributor post, no release/spec artifact.
- TensorRT-LLM v1.3.0rc24, Aug 12 - pre-release on TRT-LLM's normal weekly RC cadence; feature list only, no benchmarks.
- vLLM v0.27.2rc0, Aug 12 - pre-release; changelog body would not render to confirm claims.
- Kyverno v1.19.0-rc.3, Aug 12 - pre-release; changelog unverifiable.
- Out-of-window releases (Aug 9–11): Istio 1.31.0-alpha.2, Prometheus 3.14.0-rc.0, Argo Workflows v4.1.0, Kargo v1.11.1, wasmCloud v2.7.0, SGLang v0.5.17, NVIDIA Dynamo v1.5.0-nemotron dev.1, Volcano v1.15.0, KYAML pretty-print blog post.
- False leads discarded after primary-source checks: a search summary claiming "Kubernetes v1.35 announced Aug 12" (actually released 2025-12-17; current stable is 1.36, 1.37 in RC), and a claimed "CloudNativePG CVE-2026-44477" that did not match the primary release feed.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~15; segments shipped: 4
- Any unresolved framing concerns: The Argo CD item is deliberately framed as hardening, not a CVE — there is no security advisory dated Aug 12; the fixes follow the earlier server-side-diff secret-extraction class (CVE-2026-42880, May 2026, out of window). The vLLM item is framed on the serving/kernel path rather than the model itself to keep it infrastructure-focused.
- Any vendor-attributed claims: The Qwen3.8 hardware requirements, quantization formats, and kernel work are attributed to the vLLM project's own blog; model accuracy benchmarks were deliberately omitted as non-infrastructural and self-reported.
- Labels to apply (not settable via the PR-create tool): `news`, `content`, `needs-review`. Review requested from the configured content reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KH4GXpLjST3xUSYH8DSDef

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH4GXpLjST3xUSYH8DSDef)_