### PR TITLE
Rawkode Academy News - August 15, 2026

### DIFF
--- a/content/news/2026-08-15-talos-1-14-rc-dapr-helm-patches/index.mdx
+++ b/content/news/2026-08-15-talos-1-14-rc-dapr-helm-patches/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "Talos 1.14 opens RC with sandboxd isolation, Dapr and Helm ship patch waves"
+description: "Talos Linux v1.14.0-rc.1 introduced sandboxd workload isolation and native BGP, Dapr patched placement, scheduler, and workflow recovery across three lines, and Helm fixed server-side apply conflict retries and OCI registry push auth."
+publishedAt: 2026-08-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - dapr
+  - helm
+---
+
+A quiet Friday across the ecosystem, so this is a short digest of three primary-source releases from the last 24 hours: a node OS release candidate and two maintenance patch waves.
+
+## Talos 1.14 opens its release candidate with sandboxd workload isolation
+
+Sidero Labs published [Talos Linux v1.14.0-rc.1](https://github.com/siderolabs/talos/releases/tag/v1.14.0-rc.1) on August 14, the first release candidate for the 1.14 line of the immutable Kubernetes node OS.
+
+The headline change is `sandboxd`, which runs the container runtime, kubelet, and pods in dedicated PID and mount namespaces to isolate workloads from the host. The candidate also adds native BGP through embedded GoBGP instances, with ECMP, BFD, and route imports, rather than relying on an external routing layer; DNS over TLS and DNS over HTTPS for encrypted resolution; and declarative management of LVM logical volumes, volume groups, and RAID arrays. It ships Linux 6.18 and Kubernetes 1.37.0-rc.0, and reworks machine configuration into multiple documents.
+
+This is a testing release rather than an upgrade target, but sandboxd is worth evaluating for teams that want workload isolation enforced at the OS layer instead of through runtime configuration.
+
+**Source:** [Talos v1.14.0-rc.1 release](https://github.com/siderolabs/talos/releases/tag/v1.14.0-rc.1) - August 14, 2026
+
+---
+
+## Dapr patches placement, scheduler, and workflow recovery across three release lines
+
+The Dapr project cut [v1.18.3](https://github.com/dapr/dapr/releases/tag/v1.18.3) on August 14, with patch releases v1.17.13 and v1.16.19 across the supported 1.16 and 1.17 lines following the same day.
+
+The releases fix a placement bug where a single sidecar disconnecting reported every sidecar in the namespace as disconnected from the Placement service. On the scheduler side, they bound graceful drain to five seconds so shutdowns stop hanging and failing to redeliver jobs, add timezone validation to prevent a crash on malformed job schedules, and restore embedded etcd metrics on the metrics endpoint. Workflow fixes cover stalled workflows that stayed stuck after the last worker disconnected, intermittent `GetInstance` failures while a workflow was running, and terminate calls silently dropped when batched with other operations. Actor state store components can now be hot-reloaded without a restart.
+
+**Source:** [Dapr v1.18.3 release](https://github.com/dapr/dapr/releases/tag/v1.18.3) - August 14, 2026
+
+---
+
+## Helm 4.2.4 fixes server-side apply conflict retries and registry push auth
+
+Helm published [v4.2.4](https://github.com/helm/helm/releases/tag/v4.2.4) and v3.21.4 on August 14, patch releases across the v4 and v3 lines.
+
+The releases restore a missing conflict-retry path for server-side apply and set the correct scope for token-based authentication when pushing charts to OCI registries. They also fix a panic on repeated `IsReachable` calls and improve error reporting for `helm template --debug` with `--show-only`. Two dependency bumps pull in fixes for advisories in `google.golang.org/grpc` (GO-2026-6061) and `go.opentelemetry.io/otel` (GO-2026-5158).
+
+**Source:** [Helm v4.2.4 release](https://github.com/helm/helm/releases/tag/v4.2.4) - August 14, 2026
+
+---

--- a/content/news/2026-08-15-talos-1-14-rc-dapr-helm-patches/index.mdx
+++ b/content/news/2026-08-15-talos-1-14-rc-dapr-helm-patches/index.mdx
@@ -26,9 +26,9 @@ This is a testing release rather than an upgrade target, but sandboxd is worth e
 
 ## Dapr patches placement, scheduler, and workflow recovery across three release lines
 
-The Dapr project cut [v1.18.3](https://github.com/dapr/dapr/releases/tag/v1.18.3) on August 14, with patch releases v1.17.13 and v1.16.19 across the supported 1.16 and 1.17 lines following the same day.
+The Dapr project cut [v1.18.3](https://github.com/dapr/dapr/releases/tag/v1.18.3) on August 14, backporting the same fixes across the supported 1.16 and 1.17 lines as [v1.17.13](https://github.com/dapr/dapr/releases/tag/v1.17.13) and [v1.16.19](https://github.com/dapr/dapr/releases/tag/v1.16.19) the same day.
 
-The releases fix a placement bug where a single sidecar disconnecting reported every sidecar in the namespace as disconnected from the Placement service. On the scheduler side, they bound graceful drain to five seconds so shutdowns stop hanging and failing to redeliver jobs, add timezone validation to prevent a crash on malformed job schedules, and restore embedded etcd metrics on the metrics endpoint. Workflow fixes cover stalled workflows that stayed stuck after the last worker disconnected, intermittent `GetInstance` failures while a workflow was running, and terminate calls silently dropped when batched with other operations. Actor state store components can now be hot-reloaded without a restart.
+The releases fix a placement bug where a single sidecar disconnecting reported every sidecar in the namespace as disconnected from the Placement service. On the scheduler side, they cap graceful drain at five seconds so shutdowns stop hanging and failing to redeliver jobs, add timezone validation to prevent a crash on malformed job schedules, and restore embedded etcd metrics on the metrics endpoint. Workflow fixes cover stalled workflows that stayed stuck after the last worker disconnected, intermittent `GetInstance` failures while a workflow was running, and terminate calls silently dropped when batched with other operations. Actor state store components can now be hot-reloaded without a restart.
 
 **Source:** [Dapr v1.18.3 release](https://github.com/dapr/dapr/releases/tag/v1.18.3) - August 14, 2026
 
@@ -36,7 +36,7 @@ The releases fix a placement bug where a single sidecar disconnecting reported e
 
 ## Helm 4.2.4 fixes server-side apply conflict retries and registry push auth
 
-Helm published [v4.2.4](https://github.com/helm/helm/releases/tag/v4.2.4) and v3.21.4 on August 14, patch releases across the v4 and v3 lines.
+Helm published [v4.2.4](https://github.com/helm/helm/releases/tag/v4.2.4) and [v3.21.4](https://github.com/helm/helm/releases/tag/v3.21.4) on August 14, patch releases across the v4 and v3 lines.
 
 The releases restore a missing conflict-retry path for server-side apply and set the correct scope for token-based authentication when pushing charts to OCI registries. They also fix a panic on repeated `IsReachable` calls and improve error reporting for `helm template --debug` with `--show-only`. Two dependency bumps pull in fixes for advisories in `google.golang.org/grpc` (GO-2026-6061) and `go.opentelemetry.io/otel` (GO-2026-5158).
 


### PR DESCRIPTION
## Summary

A quiet Friday across the ecosystem. This digest ships three primary-source releases that landed inside the 24-hour coverage window: a node-OS release candidate worth evaluating (Talos 1.14) and two coordinated maintenance patch waves with concrete operational fixes (Dapr and Helm). Larger stories (Kubernetes 1.37.0-rc.0, Argo CD 3.5.1, vLLM, SGLang, containerd 2.3.4) all fell just outside the window and were excluded rather than backfilled.

## Run metadata

- Run time: `2026-08-15 06:00 Europe/London`
- Coverage window: `2026-08-14 05:16 UTC` to `2026-08-15 05:16 UTC`
- Source URLs inspected: `~34`
- Candidates longlisted: `10`
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Talos 1.14 opens its release candidate with sandboxd workload isolation - first RC moves container-runtime/kubelet/pod isolation into the OS and adds native BGP, DoT/DoH, and declarative LVM/RAID.
- Dapr patches placement, scheduler, and workflow recovery across three release lines - fixes a placement disconnect cascade and permanently-stalled workflows, backported across 1.16/1.17/1.18 the same day.
- Helm 4.2.4 fixes server-side apply conflict retries and registry push auth - restores the SSA conflict-retry path and corrects OCI push token scope, plus two security dependency bumps.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Talos v1.14.0-rc.1 published 2026-08-14; adds sandboxd isolation, native BGP (GoBGP), DoT/DoH, LVM/RAID; ships Linux 6.18 + Kubernetes 1.37.0-rc.0 | [siderolabs/talos releases/tag/v1.14.0-rc.1](https://github.com/siderolabs/talos/releases/tag/v1.14.0-rc.1) + [releases.atom](https://github.com/siderolabs/talos/releases.atom) (updated 2026-08-14T21:15:51Z) | ✅ |
| Dapr v1.18.3 published 2026-08-14 with v1.17.13 and v1.16.19 same day; placement disconnect cascade fix, scheduler drain/timezone/metrics fixes, stalled-workflow + GetInstance + terminate fixes | [dapr/dapr releases/tag/v1.18.3](https://github.com/dapr/dapr/releases/tag/v1.18.3) + [releases.atom](https://github.com/dapr/dapr/releases.atom) (v1.18.3 2026-08-14T22:39:11Z, v1.17.13 2026-08-14T23:51:38Z, v1.16.19 2026-08-15T04:06:30Z) | ✅ |
| Helm v4.2.4 and v3.21.4 published 2026-08-14; SSA conflict-retry fix, OCI registry token-auth scope fix, IsReachable panic fix; grpc GO-2026-6061 and otel GO-2026-5158 dependency bumps | [helm/helm releases/tag/v4.2.4](https://github.com/helm/helm/releases/tag/v4.2.4) + [releases.atom](https://github.com/helm/helm/releases.atom) (updated 2026-08-14T15:03:07Z) | ✅ |

## Items considered and dropped

- Crossplane v2.5.0-rc.0 - primary RC timestamped 2026-08-13T19:07Z, outside the 24h window (only a v2.4.0-rc.1 retag fell inside).
- arXiv "OpScale: Operator-level Provisioning and Autoscaling for LLM Serving" - strong fit, but submission date is 2026-08-13 (announced 08-14); outside the window.
- Argo Workflows v4.1.1 / v4.0.9 / v3.7.18 (2026-08-14) - coordinated patch wave, but contents are routine logging/sync/nil-pointer backports with no CVE; below the substance bar.
- Linkerd edge-26.8.2 (2026-08-14) - single dependency bump and a duplicate-informer fix; trivial.
- CNCF "self-healing Kubernetes upgrade pipeline on Kairos" blog (2026-08-14) - community how-to, not a release or newsworthy artifact.
- Kubernetes 1.37.0-rc.0, Argo CD 3.5.1, Prometheus 3.14.0-rc.0, containerd 2.3.4, vLLM 0.27.x, SGLang 0.5.17, Ray 2.57.0 - all 2026-08-10 to 08-12, outside the window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 10
- Segments shipped: 3
- Any unresolved framing concerns: Talos 1.14 is a release candidate, framed explicitly as a preview rather than an upgrade target.
- Any vendor-attributed claims: none - all three segments cite project-published GitHub releases.
- Branch note: this branch (`claude/beautiful-dijkstra-5qsltu`) carried four pre-existing, unrelated maintenance commits (video-importer/thumbnails/stream-import fixes, 19 files) before this run. Per branch policy they were kept rather than discarded, so they appear in this PR's diff. Only `content/news/2026-08-15-talos-1-14-rc-dapr-helm-patches/index.mdx` belongs to today's digest and needs news review.

---
_Generated by [Claude Code](https://claude.ai/code/session_016R9fFPs9MHGpbtJ7Rc4fzp)_