### PR TITLE
Rawkode Academy News - August 18, 2026

### DIFF
--- a/content/news/2026-08-18-kubeflow-graduated-dynamo-llm-d-otel-harbor/index.mdx
+++ b/content/news/2026-08-18-kubeflow-graduated-dynamo-llm-d-otel-harbor/index.mdx
@@ -1,0 +1,71 @@
+---
+title: "Kubeflow graduates from the CNCF, Dynamo 1.4 adds multi-datacenter KV routing, OpenTelemetry Collector gates queue batching"
+description: "The CNCF graduated Kubeflow on August 17, while NVIDIA Dynamo 1.4, llm-d 0.9, the OpenTelemetry Collector, and Harbor all shipped same-day releases across inference, observability, and registry infrastructure."
+publishedAt: 2026-08-18
+authors:
+  - rawkode
+technologies:
+  - kubeflow
+  - llm-d
+  - opentelemetry
+  - harbor
+  - kubernetes
+---
+
+August 17 was a busy day across the cloud native and AI-infrastructure stack. Five primary-source items landed inside the last 24 hours: a CNCF graduation, two distributed-inference releases, an OpenTelemetry Collector release with breaking config edits, and a Harbor patch that quietly re-bases its bundled database.
+
+## Kubeflow graduates from the CNCF
+
+The CNCF [announced on August 17](https://www.cncf.io/announcements/2026/08/17/cncf-announces-kubeflows-graduation-solidifying-the-standard-for-cloud-native-ai-operations/) that Kubeflow has reached graduated status, the foundation's top maturity tier and among the first AI/ML-focused projects to get there.
+
+Kubeflow now spans the full lifecycle — data processing, notebooks, distributed training and fine-tuning, and model serving through KServe — with recent additions aimed at post-training and agentic workloads. The CNCF cites more than 6,600 contributors across over 1,000 organizations, roughly 260 million cumulative PyPI downloads, and production adopters including Bloomberg, NVIDIA, Red Hat, LinkedIn, and Spotify. Graduation required a third-party security audit, a formal steering committee, and adoption of the CNCF Code of Conduct. The project integrates with Kueue for job queuing, Istio for service traffic, and Prometheus for monitoring.
+
+The signal for platform teams is that the vendor-neutral, Kubernetes-native MLOps stack now carries the CNCF's strongest maturity guarantee, which matters when standardizing training and serving paths for internal AI platforms.
+
+**Source:** [CNCF](https://www.cncf.io/announcements/2026/08/17/cncf-announces-kubeflows-graduation-solidifying-the-standard-for-cloud-native-ai-operations/) - August 17, 2026
+
+---
+
+## NVIDIA Dynamo 1.4 adds multi-datacenter KV routing and multimodal disaggregation
+
+NVIDIA released [Dynamo 1.4.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.4.0) on August 17, the 17th feature release of its open distributed-inference platform, with 640 merged PRs from 127 contributors.
+
+The release adds a sequenced, datacenter-scoped KV relay that extends prefix-cache-aware routing across datacenters, backed by a reservation replay cache that records routing decisions instead of resending long prompts. It introduces an experimental vLLM-compatible `/inference/v1/generate` token-in/token-out endpoint on the Dynamo frontend, and uses NIXL RDMA tensor transport to disaggregate multimodal, autoregressive-to-diffusion pipelines such as GLM-Image across nodes. The bundled Spica discrete-event simulator moved into the main repository for GPU-free capacity planning, and the process-local tokenizer prefix cache is now enabled by default with a 64 MiB budget. Dynamo 1.4 tracks vLLM 0.26.0 with FlashInfer 0.6.14.
+
+**Source:** [NVIDIA Dynamo v1.4.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.4.0) - August 17, 2026
+
+---
+
+## llm-d 0.9 bumps vLLM to 0.26 and adds Intel XPU support
+
+The llm-d project — the Kubernetes-native distributed inference stack built on vLLM — published [v0.9.0](https://github.com/llm-d/llm-d/releases/tag/v0.9.0) on August 17.
+
+The release upgrades the bundled vLLM from 0.23.0 to 0.26.0 across its CUDA, ROCm, CPU, TPU, and XPU variants, and adds Intel XPU support, including a tiered prefix cache backed by the LMCache connector for KV offload. Routing guidance moves from request-based to token-aware load balancing, and the endpoint-picker autoscaling path shifts from the Prometheus Adapter to KEDA queue-based scaling.
+
+Both changes point the same way: llm-d is standardizing on queue- and token-aware signals rather than raw request counts as the basis for scaling inference under load.
+
+**Source:** [llm-d v0.9.0](https://github.com/llm-d/llm-d/releases/tag/v0.9.0) - August 17, 2026
+
+---
+
+## OpenTelemetry Collector gates queue batching and renames exporter config fields
+
+The OpenTelemetry Collector released [v1.65.0/v0.159.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.159.0) on August 17.
+
+A new `pkg.exporterhelper.queueBatchEnabled` feature gate turns on batching inside `NewDefaultQueueConfig`, advancing Phase 1 of the exporter batching migration RFC by moving batching into the exporter queue rather than a standalone batch processor. The release also lands two breaking changes that convert embedded structs to named fields: the zpages extension's `confighttp.ServerConfig`, and `configauth.Config` inside confighttp's `AuthConfig`. It adds `otelcol_exporter_enqueue_size` and `otelcol_exporter_enqueue_size_bytes` metrics, and now records batch send-size histograms after batching rather than on the incoming request.
+
+Teams maintaining custom collector builds or config structs need to update for the renamed fields, and anyone testing the batching migration should watch the new enqueue-size metrics.
+
+**Source:** [OpenTelemetry Collector v0.159.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.159.0) - August 17, 2026
+
+---
+
+## Harbor 2.15.2 auto-upgrades its bundled Postgres from 15 to 18
+
+Harbor released [v2.15.2](https://github.com/goharbor/harbor/releases/tag/v2.15.2) on August 17, a patch that carries a significant operational change for its packaged database.
+
+On container startup the release runs `pg_upgrade` to move the bundled PostgreSQL from 15 to 18, so operators using the packaged database should back up first and expect a possible reindex for non-ASCII data. The release also swaps the bundled Redis cache for Valkey, upgrades the UI to Angular 21 and Node.js 22, and tightens security by validating the source project on blob mounts and rejecting tokens that omit an `iat` claim.
+
+**Source:** [Harbor v2.15.2](https://github.com/goharbor/harbor/releases/tag/v2.15.2) - August 17, 2026
+
+---

--- a/content/news/2026-08-18-kubeflow-graduated-dynamo-llm-d-otel-harbor/index.mdx
+++ b/content/news/2026-08-18-kubeflow-graduated-dynamo-llm-d-otel-harbor/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Kubeflow graduates from the CNCF, Dynamo 1.4 adds multi-datacenter KV routing, OpenTelemetry Collector gates queue batching"
+title: "Kubeflow graduates from the CNCF; Dynamo, llm-d, OpenTelemetry Collector, and Harbor ship same-day releases"
 description: "The CNCF graduated Kubeflow on August 17, while NVIDIA Dynamo 1.4, llm-d 0.9, the OpenTelemetry Collector, and Harbor all shipped same-day releases across inference, observability, and registry infrastructure."
 publishedAt: 2026-08-18
 authors:


### PR DESCRIPTION
## Summary

Five primary-source items landed within the August 17 coverage window, across MLOps governance, distributed AI inference, observability, and registry infrastructure. Kubeflow's CNCF graduation leads the digest; NVIDIA Dynamo 1.4 and llm-d 0.9 both shipped substantive distributed-inference releases on the same day; the OpenTelemetry Collector advanced its exporter batching migration with breaking config changes; and Harbor 2.15.2 carries a notable operational change to its bundled database. Weaker or unverifiable candidates (JAX 0.11.1, Kargo patches, a Mimir weekly Helm cut, and the Istio 1.31 beta) were dropped rather than padded in.

## Run metadata

- Run time: `2026-08-18 06:00 Europe/London`
- Coverage window: `2026-08-17 06:00 Europe/London` to `2026-08-18 06:00 Europe/London` (last 24 hours)
- Source URLs inspected: `~45` (direct fetches plus four category discovery sweeps)
- Candidates longlisted: `~12`
- Candidates shortlisted: `6`
- Segments shipped: `5`
- Time horizon: last 24 hours only

## Segments

- Kubeflow graduates from the CNCF - top maturity tier for the Kubernetes-native MLOps stack, signaling production-grade standardization for AI platforms.
- NVIDIA Dynamo 1.4 adds multi-datacenter KV routing and multimodal disaggregation - extends prefix-cache-aware routing across datacenters and disaggregates autoregressive-to-diffusion pipelines over NIXL RDMA.
- llm-d 0.9 bumps vLLM to 0.26 and adds Intel XPU support - moves routing to token-aware balancing and autoscaling from Prometheus Adapter to KEDA.
- OpenTelemetry Collector gates queue batching and renames exporter config fields - Phase 1 batching migration plus two breaking embedded-to-named field changes.
- Harbor 2.15.2 auto-upgrades its bundled Postgres from 15 to 18 - runs pg_upgrade on startup and swaps Redis for Valkey, an operational heads-up for operators of the packaged database.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Kubeflow graduated; 6,600+ contributors, 1,000+ orgs, ~260M PyPI downloads, adopters Bloomberg/NVIDIA/Red Hat/LinkedIn/Spotify; security audit + steering committee | [CNCF announcement, Aug 17 2026](``https://www.cncf.io/announcements/2026/08/17/cncf-announces-kubeflows-graduation-solidifying-the-standard-for-cloud-native-ai-operations/``) | ✅ |
| Dynamo 1.4.0, 640 PRs / 127 contributors; multi-datacenter KV relay; vLLM-compatible `/inference/v1/generate`; NIXL RDMA multimodal disaggregation; Spica simulator; 64 MiB tokenizer cache; vLLM 0.26.0 / FlashInfer 0.6.14 | [ai-dynamo/dynamo v1.4.0 release + releases.atom (`2026-08-17T22:19:24Z`)](https://github.com/ai-dynamo/dynamo/releases/tag/v1.4.0) | ✅ |
| llm-d 0.9.0; vLLM 0.23.0 -> 0.26.0 across variants; Intel XPU support + LMCache tiered prefix cache; token-aware routing; KEDA autoscaling | [llm-d/llm-d v0.9.0 release + releases.atom (`2026-08-17T23:38:59Z`)](https://github.com/llm-d/llm-d/releases/tag/v0.9.0) | ✅ |
| OTel Collector v1.65.0/v0.159.0; `pkg.exporterhelper.queueBatchEnabled` gate; zpages/AuthConfig embedded->named breaking changes; new enqueue-size metrics; post-batch histograms | [opentelemetry-collector v0.159.0 release + releases.atom (`2026-08-17T17:37:33Z`)](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.159.0) | ✅ |
| Harbor v2.15.2; bundled PostgreSQL 15 -> 18 via pg_upgrade on startup; Redis -> Valkey; Angular 21 / Node.js 22; blob-mount source validation; reject tokens missing `iat` | [goharbor/harbor v2.15.2 release + releases.atom (`2026-08-17T09:30:23Z`)](https://github.com/goharbor/harbor/releases/tag/v2.15.2) | ✅ |

## Items considered and dropped

- JAX v0.11.1 (Aug 17) - genuine in-window release, but a numerical-library patch (NumPy-parity additions, `take_along_axis` default change) with low relevance/actionability for cloud native and platform/HPC infrastructure readers.
- Kargo v1.11.2 and v1.10.10 (Aug 18 03:17-03:18 UTC) - in-window but minor GitOps promotion bugfixes (SSO redirect, GitHub App token validation); below the substance bar.
- Mimir `mimir-distributed-6.3.0-weekly.408` (Aug 17) - automated weekly Helm chart cut with no documented features or fixes.
- Istio 1.31.0-beta.1 (Aug 17) - a beta pre-release whose notes would not load from any accessible source; substance could not be verified, so cut rather than guessed.
- VictoriaMetrics v1.150.0 - Aug 17 tag activity was a mirror re-push; the release itself is dated Aug 14, out of window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~12 in-window, plus dozens of out-of-window releases eliminated on the freshness gate
- Segments shipped: 5
- Any unresolved framing concerns: Dynamo and llm-d are both distributed-inference releases; kept both as they are distinct projects (NVIDIA's engine-agnostic platform vs the Kubernetes-native community stack) with independent, same-day feature drops. The digest leans AI-infra heavy because that is what actually shipped on Aug 17.
- Any vendor-attributed claims: Dynamo's internal micro-benchmarks were deliberately omitted; only architectural/feature changes are reported. All other claims trace to primary release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwDYcTb61Sga8YCXpLMhop

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwDYcTb61Sga8YCXpLMhop)_