### PR TITLE
Rawkode Academy News - August 19, 2026

### DIFF
--- a/content/news/2026-08-19-cloud-native-digest/index.mdx
+++ b/content/news/2026-08-19-cloud-native-digest/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "Cloud native digest for 19 August 2026: Prometheus 3.14, a Cilium NodePort outage fix, CoreDNS security rebuild, and Backstage auth hardening"
+description: "Prometheus 3.14.0 turns duration expressions on by default and promotes first_over_time to stable, while Cilium ships a coordinated patch for a BPF map collision that could drop NodePort traffic for ~30 minutes."
+publishedAt: 2026-08-19
+authors:
+  - rawkode
+technologies: []
+---
+
+### Prometheus 3.14.0 enables duration expressions by default and promotes first_over_time to stable
+
+Prometheus published 3.14.0 on 18 August 2026, with two changes that alter default query behaviour and one that removes a feature flag.
+
+The release enables PromQL duration expressions by default, making the `--enable-feature=promql-duration-expr` flag a no-op ([#19033](https://github.com/prometheus/prometheus/pull/19033)), and promotes `first_over_time` from experimental to a stable function ([#19093](https://github.com/prometheus/prometheus/pull/19093)). New in this cycle: Oracle Cloud Infrastructure compute service discovery ([#18919](https://github.com/prometheus/prometheus/pull/18919)) and an experimental `start_timestamp()` function for instant vectors ([#19089](https://github.com/prometheus/prometheus/pull/19089)). On the storage side, the notes call out fixes for a data-loss risk in the TSDB under out-of-order ingestion ([#19016](https://github.com/prometheus/prometheus/pull/19016)) and native histogram corruption after a restart ([#19202](https://github.com/prometheus/prometheus/pull/19202)).
+
+If you gate recording or alerting rules on duration-expression syntax, the flag change means expressions parse everywhere on 3.14.0 whether or not the flag is set, so audit rule files before rolling out.
+
+**Source:** [Prometheus v3.14.0 release notes](https://github.com/prometheus/prometheus/releases/tag/v3.14.0) — 18 August 2026
+
+---
+
+### Cilium patches a BPF map collision that could drop NodePort traffic for 30 minutes
+
+Cilium shipped a coordinated patch across three maintained branches on 18 August 2026 — 1.20.1, 1.19.7, and 1.18.13 — led by a load-balancing datapath fix rather than a security advisory.
+
+The headline bug is a BPF load-balancer map key collision in which HostPort or NodePort expansion could overwrite a LoadBalancer frontend, and the release notes describe a roughly 30-minute NodePort outage after a LoadBalancer service is deleted. The same set of releases corrects a case where, with kube-proxy replacement disabled, Cilium intercepted traffic destined for LoadBalancer VIPs that should have been delegated to kube-proxy, and fixes a BPF verifier rejection on pre-5.12 kernels when IPv6 is enabled.
+
+Operators running any of the three supported branches with NodePort or LoadBalancer services should treat the datapath fix as upgrade-worthy, since the failure mode is a silent traffic outage rather than a crash.
+
+**Source:** [Cilium v1.19.7 release notes](https://github.com/cilium/cilium/releases/tag/v1.19.7) — 18 August 2026
+
+---
+
+### CoreDNS 1.14.7 rebuilds on Go 1.26.6 to pick up three CVE fixes
+
+CoreDNS released 1.14.7 on 19 August 2026, a maintenance and hardening release built on a patched Go toolchain.
+
+Per the release notes, the build uses Go 1.26.6 to include fixes for CVE-2026-56865, CVE-2026-56864, and CVE-2026-33818, and the changelog groups roughly 49 noteworthy changes across caching, forwarding, and transport. The stated focus is reliability: improved stale-cache behaviour, safer upstream handling, and tighter connection and overload controls.
+
+Because CoreDNS sits on the resolution path for effectively every workload in a cluster, a toolchain-level CVE rebuild plus resolver-reliability fixes is worth folding into the next patch window rather than deferring.
+
+**Source:** [CoreDNS v1.14.7 release notes](https://github.com/coredns/coredns/releases/tag/v1.14.7) — 19 August 2026
+
+---
+
+### Backstage 1.54.0 tightens OAuth redirect-URI allowlist matching as a breaking change
+
+Backstage cut 1.54.0 on 18 August 2026, and the auth backend carries a breaking change that can lock out logins if operator config is not reviewed.
+
+The OAuth redirect URI and client-ID metadata allowlists in `@backstage/plugin-auth-backend` now match patterns per URL component instead of against the full URL string. Wildcards no longer cross host or path boundaries, patterns must include an explicit protocol, redirect URIs with embedded credentials are always rejected, and a wildcard port such as `http://localhost:*` now matches only the root path. The release also removes the previously deprecated extension `config.schema` and restructures the Connections API, both flagged as breaking.
+
+Portal operators upgrading from 1.53.x should re-derive their allowlist entries against the per-component rules before deploying, since an over-broad wildcard that previously worked may now fail to match a valid callback.
+
+**Source:** [Backstage v1.54.0 release notes](https://github.com/backstage/backstage/releases/tag/v1.54.0) — 18 August 2026
+
+---

--- a/content/news/2026-08-19-cloud-native-digest/index.mdx
+++ b/content/news/2026-08-19-cloud-native-digest/index.mdx
@@ -4,7 +4,11 @@ description: "Prometheus 3.14.0 turns duration expressions on by default and pro
 publishedAt: 2026-08-19
 authors:
   - rawkode
-technologies: []
+technologies:
+  - prometheus
+  - cilium
+  - coredns
+  - backstage
 ---
 
 ### Prometheus 3.14.0 enables duration expressions by default and promotes first_over_time to stable


### PR DESCRIPTION
## Summary

Daily cloud native / platform engineering / AI-HPC news digest for 19 August 2026. Four segments passed the full pipeline, each anchored to a primary release note published inside the strict 24-hour coverage window: Prometheus 3.14.0 (a GA minor with two default-behaviour changes), a coordinated Cilium datapath patch for a NodePort-outage bug, the CoreDNS 1.14.7 Go security rebuild, and the Backstage 1.54.0 breaking OAuth allowlist change. The AI/HPC feeds (vLLM, SGLang, TensorRT-LLM, Ray, llama.cpp, Volcano, Kueue) produced only nightlies and release candidates in this window, so none were shipped — this digest is intentionally infra-heavy rather than padded.

## Run metadata

- Run time: `2026-08-19 06:00 Europe/London`
- Coverage window: `2026-08-18 06:00 Europe/London` to `2026-08-19 06:00 Europe/London` (`2026-08-18T05:00Z`–`2026-08-19T05:00Z`)
- Source URLs inspected: `~44`
- Candidates longlisted: `14`
- Candidates shortlisted: `6`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- Prometheus 3.14.0 - duration expressions on by default and `first_over_time` stable change default query behaviour; TSDB data-loss and native-histogram fixes.
- Cilium 1.20.1 / 1.19.7 / 1.18.13 - coordinated patch for a BPF LB map collision that could drop NodePort traffic for ~30 minutes after a LoadBalancer delete.
- CoreDNS 1.14.7 - Go 1.26.6 rebuild pulling in three CVE fixes plus resolver reliability hardening on the cluster-wide DNS path.
- Backstage 1.54.0 - breaking OAuth redirect-URI allowlist change that can lock out logins if operator config is not reviewed.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| 3.14.0 published 2026-08-18 (feed `<updated>` 08:49Z; changelog dated 2026-08-17) | github.com/prometheus/prometheus releases.atom + release tag v3.14.0 | ✅ |
| duration expressions enabled by default, `promql-duration-expr` now a no-op (#19033) | Prometheus v3.14.0 release notes, [CHANGE] | ✅ |
| `first_over_time` promoted to stable (#19093); OCI compute SD added (#18919) | Prometheus v3.14.0 release notes | ✅ |
| TSDB out-of-order data-loss fix (#19016); native histogram corruption after restart fix (#19202) | Prometheus v3.14.0 release notes, [BUGFIX] | ✅ |
| Cilium 1.20.1/1.19.7/1.18.13 published 2026-08-18 (09:32–10:36Z); not a CVE release | github.com/cilium/cilium releases.atom + tags v1.20.1/v1.19.7 | ✅ |
| BPF LB map key collision (HostPort/NodePort expansion overwriting a LoadBalancer frontend) → ~30-min NodePort outage after LoadBalancer delete | Cilium v1.19.7 release notes | ✅ |
| KPR-disabled VIP interception fix; pre-5.12 kernel IPv6 BPF verifier fix | Cilium v1.19.7 release notes | ✅ |
| CoreDNS 1.14.7 published 2026-08-19 (feed `<updated>` 01:39Z) | github.com/coredns/coredns releases.atom | ✅ |
| Built with Go 1.26.6 to include fixes for CVE-2026-56865, CVE-2026-56864, CVE-2026-33818; ~49 noteworthy changes | CoreDNS v1.14.7 release notes (security line verbatim, one CVE hyperlinked to advisory) | ✅ |
| Backstage 1.54.0 published 2026-08-18 (feed `<updated>` 19:17Z) | github.com/backstage/backstage releases.atom | ✅ |
| Breaking: `@backstage/plugin-auth-backend` OAuth redirect-URI/client-ID allowlists now match per URL component; wildcards no longer cross host/path; embedded-credential redirect URIs rejected | Backstage v1.54.0 release notes | ✅ |

## Items considered and dropped

- Grafana v13.2.0 / v13.1.4 / v13.0.7 / v12.4.9 / v12.3.11 (2026-08-18) - coordinated 5-branch backport referencing CVE-2026-17183, but the advisory is not yet published and the release notes give no vulnerability type/severity, so the segment could not be written without inventing detail. See reviewer notes.
- Longhorn v1.12.1 (2026-08-19) - in-window CNCF storage release; the notes present V2 Data Engine fast cloning and erasure-coding "storage sharding" plus default-on internal NetworkPolicy, but whether the experimental features are new in 1.12.1 vs carried from 1.12.0 could not be cleanly verified, so it was held rather than risk mis-attribution.
- Istio 1.31.0-beta.2, Kyverno v1.19.0-rc.4, Dapr v1.16.20-rc.1, TensorRT-LLM v1.3.0rc23.post1 - prereleases/RCs, not GA news.
- llama.cpp `bXXXXX` builds, Spin `canary`, Wasmtime `dev` tag - rolling/nightly CI artifacts, not releases.
- Kargo v1.11.2 / v1.10.10 (2026-08-18T03:18Z) - published before the 05:00Z window start; outside the 24h horizon.
- OTel Collector v1.65.0/v0.159.0, OTel Collector-Contrib v0.159.0, Argo CD, Argo Workflows, containerd, Cluster API, Trivy, Kueue, Volcano, Ray, SGLang - most recent releases predate the window (Aug 11-17).
- CNCF Ambassador post "Cloud Native platform sovereignty through multi-plane architecture" (2026-08-18) - opinion/pedagogical piece, no release, spec, or project change.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 14 in-window
- Segments shipped: 4
- Any unresolved framing concerns: **Grafana CVE-2026-17183** — the five backported releases clearly reference this CVE, which is a genuine "upgrade now" operational signal, but Grafana's public security-advisories page did not list it at run time and the release notes carry no vulnerability description. Rather than characterise a vulnerability I could not verify, I dropped the segment. Worth a human eye if the advisory publishes.
- Any vendor-attributed claims: The CoreDNS Go-CVE line is quoted from the project's own release notes (primary source); no independent-benchmark or vendor-marketing claims are carried in this digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XVepaGqzCshKDS36a2VRc

---
_Generated by [Claude Code](https://claude.ai/code/session_017XVepaGqzCshKDS36a2VRc)_