### PR TITLE
Rawkode Academy News - August 20, 2026

### DIFF
--- a/content/news/2026-08-20-crossplane-2-4-backstage-1-54-grafana-13-2/index.mdx
+++ b/content/news/2026-08-20-crossplane-2-4-backstage-1-54-grafana-13-2/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "Crossplane 2.4 restarts package pods on upgrade, Backstage 1.54 tightens OAuth, Grafana 13.2 moves alerting to v1beta1"
+description: "Crossplane 2.4.0 reworks package revisions and lets functions watch required resources, Backstage 1.54.0 hardens OAuth redirect matching and diffs catalog relations, and Grafana 13.2.0 migrates its notifications API to v1beta1."
+publishedAt: 2026-08-20
+authors:
+  - rawkode
+technologies:
+  - crossplane
+  - backstage
+  - grafana
+---
+
+Three primary-source releases landed across control planes, developer portals, and observability in the last 24 hours. All three carry operational consequences worth reading before you upgrade.
+
+## Crossplane 2.4 restarts every package pod on upgrade and lets functions watch required resources
+
+Crossplane published [v2.4.0](https://github.com/crossplane/crossplane/releases/tag/v2.4.0) on August 20, the latest stable release on the v2 control-plane line.
+
+Package revision names now incorporate both the package digest and `metadata.generation`, so any spec change mints a new `PackageRevision`. As a result, upgrading to 2.4 issues a new revision for every installed package and restarts the pods for all Providers and Functions. Package runtime objects move to server-side apply under the `pkg.crossplane.io/runtime` field manager, so fields removed from a `DeploymentRuntimeConfig` are now deleted from live objects instead of lingering. Composition functions can trigger reconciliation when a required, non-composed resource changes rather than waiting for the next poll, and providers with safe-start scale to zero replicas until their first `ManagedResourceDefinition` becomes active. The composed-resource garbage collector now validates controller references before acting on `spec.resourceRefs`, closing a path where it could delete resources it did not own.
+
+Operators should plan for the package-pod restart during the upgrade; the CLI has also moved to `cli.crossplane.io` and the binary is now named `crossplane` rather than `crank`.
+
+**Source:** [Crossplane v2.4.0 release](https://github.com/crossplane/crossplane/releases/tag/v2.4.0) - August 20, 2026
+
+---
+
+## Backstage 1.54 tightens OAuth redirect matching and syncs catalog relations by diff
+
+The Backstage maintainers released [v1.54.0](https://github.com/backstage/backstage/releases/tag/v1.54.0) on August 19.
+
+OAuth redirect URI allowlist matching now validates each URL component separately, so configured wildcards no longer cross host or path boundaries and URIs carrying embedded credentials are rejected. This is a breaking change for deployments that relied on looser matching. The catalog now applies only relation diffs instead of deleting and reinserting the full relation set, and entity-provider mutations retry on PostgreSQL deadlocks, cutting write churn on large catalogs. A new `refresh-catalog-entity` scaffolder action re-queues an entity immediately so automation can read back data right after a template run, and Kubernetes and MCP actions now emit auditor events. The deprecated `config.schema` extension option is removed in favour of a top-level `configSchema` that takes Standard Schema-compatible values such as Zod v4.
+
+**Source:** [Backstage v1.54.0 release](https://github.com/backstage/backstage/releases/tag/v1.54.0) - August 19, 2026
+
+---
+
+## Grafana 13.2 moves the notifications API to v1beta1 and adds GitLab and Bitbucket webhooks to Git Sync
+
+Grafana released [v13.2.0](https://github.com/grafana/grafana/releases/tag/v13.2.0) on August 19, addressing CVE-2026-17183.
+
+Alerting migrates its notifications API to `v1beta1` and gains an import path into Grafana-managed alerting: an Import tab plus a wizard that stages configuration, previews it, and can promote and auto-sync it, with contact-point provenance mismatches now returning 403 instead of 500. Git Sync provisioning adds GitLab and Bitbucket webhook support alongside GitHub Enterprise, which is now enabled by default, plus pull-request preview diffs against the merge base and per-repository webhook disabling. Dashboards can nest tabs up to four levels, interpolate thresholds, and surface panel query errors and notices in a single view; scripted dashboards are deprecated and disabled by default.
+
+**Source:** [Grafana v13.2.0 release](https://github.com/grafana/grafana/releases/tag/v13.2.0) - August 19, 2026
+
+---

--- a/content/news/2026-08-20-crossplane-2-4-backstage-1-54-grafana-13-2/index.mdx
+++ b/content/news/2026-08-20-crossplane-2-4-backstage-1-54-grafana-13-2/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Crossplane 2.4 restarts package pods on upgrade, Backstage 1.54 tightens OAuth, Grafana 13.2 moves alerting to v1beta1"
+title: "Crossplane 2.4 restarts package pods on upgrade, Backstage 1.54 tightens OAuth, Grafana 13.2 moves notifications API to v1beta1"
 description: "Crossplane 2.4.0 reworks package revisions and lets functions watch required resources, Backstage 1.54.0 hardens OAuth redirect matching and diffs catalog relations, and Grafana 13.2.0 migrates its notifications API to v1beta1."
 publishedAt: 2026-08-20
 authors:


### PR DESCRIPTION
## Summary

Three primary-source releases shipped in the last 24 hours, each with a real operational consequence for platform and observability teams: Crossplane 2.4.0 (control plane), Backstage 1.54.0 (developer portal), and Grafana 13.2.0 (observability). It was otherwise a quiet window, so this is a tight three-segment digest rather than a padded one. Everything here traces to a GitHub release published within the coverage window; no pre-releases, vendor positioning, or older resurfaced news made the cut.

## Run metadata

- Run time: `2026-08-20 06:00 Europe/London`
- Coverage window: `2026-08-19 05:00 UTC` to `2026-08-20 05:00 UTC`
- Source URLs inspected: `~30`
- Candidates longlisted: `10`
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Crossplane 2.4 restarts every package pod on upgrade and lets functions watch required resources - upgrade-time pod restarts and new reconciliation triggers change how operators run control planes.
- Backstage 1.54 tightens OAuth redirect matching and syncs catalog relations by diff - a breaking auth change plus catalog write-churn reductions for large portals.
- Grafana 13.2 moves the notifications API to v1beta1 and adds GitLab and Bitbucket webhooks to Git Sync - alerting API migration and broader GitOps provisioning for dashboards-as-code.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Crossplane v2.4.0 released 2026-08-20 | github.com/crossplane/crossplane releases.atom (v2.4.0 entry, 2026-08-20T00:40:38Z) | ✅ |
| Package revision names include digest + `metadata.generation`; upgrade restarts Provider/Function pods | Crossplane v2.4.0 release notes, Notable/Breaking Changes | ✅ |
| Runtime objects use server-side apply under `pkg.crossplane.io/runtime`; functions can watch required resources; safe-start scale-to-zero; GC validates controller refs; CLI moved to cli.crossplane.io (crank→crossplane) | Crossplane v2.4.0 release notes, Highlights | ✅ |
| Backstage v1.54.0 released 2026-08-19 | github.com/backstage/backstage releases.atom (v1.54.0 entry, 2026-08-19T11:20:23Z) | ✅ |
| Stricter OAuth redirect URI matching (breaking); catalog relation diff sync; deadlock retry; `refresh-catalog-entity` action; K8s/MCP auditor events; `config.schema` removed for top-level `configSchema` (Zod v4) | Backstage v1.54.0 release notes, Breaking Changes + Highlights | ✅ |
| Grafana v13.2.0 released 2026-08-19; addresses CVE-2026-17183 | github.com/grafana/grafana releases.atom (v13.2.0 entry, 2026-08-19T12:31:30Z) + Security section | ✅ |
| Notifications API migrated to v1beta1; import wizard/Import tab; 403 on provenance mismatch; GitLab + Bitbucket webhooks; GitHub Enterprise default; nested tabs to 4 levels; scripted dashboards deprecated | Grafana v13.2.0 release notes, Alerting/Git Sync/Dashboards | ✅ |

## Items considered and dropped

- Istio 1.31.0-rc.0 (2026-08-19 14:07 UTC) - pre-release release candidate; feature substance could not be independently verified, and an RC is not an upgrade target. Dropped.
- Talos v1.13.9 (2026-08-19 08:03 UTC) - routine patch (Kubernetes 1.36.3, Linux 6.18.44, nftables buffer sizing); too thin to carry a segment. Dropped.
- CoreDNS v1.14.7 (2026-08-19 01:39 UTC) - roughly 3 hours before the 24-hour window opened; failed the freshness gate. Dropped.
- Cilium 1.20.1 / 1.19.7 / 1.18.13 (2026-08-18) and Prometheus 3.14.0 (2026-08-18) - outside the 24-hour window. Dropped.
- arXiv cs.DC candidates - timestamps and identifiers could not be reliably verified against the window; dropped to avoid unverifiable citations.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 10
- Segments shipped: 3
- Any unresolved framing concerns: none
- Any vendor-attributed claims: none; every claim traces to the project's own GitHub release notes. Grafana's CVE-2026-17183 reference was reproduced consistently across two independent reads of the release notes but was not cross-checked against a separate advisory database, so treat the exact identifier as project-reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169siJM8aMG3Tk8X1Ud9BCd

---
_Generated by [Claude Code](https://claude.ai/code/session_0169siJM8aMG3Tk8X1Ud9BCd)_