### PR TITLE
Rawkode Academy News - August 21, 2026

### DIFF
--- a/content/news/2026-08-21-wasmtime-sandbox-escape-crossplane-2-4-kueue-tas/index.mdx
+++ b/content/news/2026-08-21-wasmtime-sandbox-escape-crossplane-2-4-kueue-tas/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "Wasmtime patches a filesystem sandbox escape, Crossplane 2.4 adds dependency watches, Kueue fixes DRA quota accounting"
+description: "Wasmtime shipped a coordinated patch wave for a high-severity filesystem sandbox escape (CVSS 8.8), Crossplane 2.4.0 lets composition functions watch resources they don't own, and Kueue 0.19.2/0.18.6 corrected DRA quota undercounting for GPU workloads."
+publishedAt: 2026-08-21
+authors:
+  - rawkode
+technologies:
+  - webassembly
+  - crossplane
+  - kueue
+  - kubernetes
+---
+
+Four primary-source releases in the last 24 hours span WebAssembly sandboxing, platform engineering, and GPU-aware batch scheduling. The Wasmtime advisory is the one to action today.
+
+## Wasmtime patches a filesystem sandbox escape across four release branches
+
+The Bytecode Alliance published [advisory GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg) on August 20, describing a filesystem sandbox escape rated CVSS 8.8. A guest granted read or write access to a preopened directory through `wasmtime-wasi` could use a trailing slash on a path or symlink to escape the sandbox and reach the host filesystem. The root cause is in the `cap-std` dependency (GHSA-hp8f-xmx4-4qrg), not Wasmtime's own path logic.
+
+The exposure is platform-dependent: hosts on Linux kernels older than 5.6, which lack the `openat2` syscall, and macOS are affected, while newer Linux kernels using the `RESOLVE_BENEATH` resolution flag are not. Fixes shipped the same day as patches to every supported line — [24.0.13](https://github.com/bytecodealliance/wasmtime/releases/tag/v24.0.13), [36.0.14](https://github.com/bytecodealliance/wasmtime/releases/tag/v36.0.14), 46.0.3, and 47.0.4 — alongside the feature release 48.0.0.
+
+Anyone running untrusted modules with WASI filesystem access on macOS or pre-5.6 kernels should patch rather than rely on the kernel-level mitigation.
+
+**Source:** [Wasmtime security advisory GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg) - August 20, 2026
+
+---
+
+## Crossplane 2.4.0 lets composition functions watch required resources
+
+Crossplane released [v2.4.0](https://github.com/crossplane/crossplane/releases/tag/v2.4.0) on August 20. Composition functions can now watch resources they depend on but do not create: a change to a required resource triggers immediate reconciliation of the dependent composite resource instead of waiting for the next poll interval. The release also adds safe-start provider scaling, letting providers scale their runtime deployment to zero replicas until their first `ManagedResourceDefinition` becomes active, and switches container image builds to nixpkgs' `buildGoModule` so scanners like Trivy and Grype can see third-party dependencies.
+
+Several breaking changes land in the same release: the CLI now distributes only from `cli.crossplane.io`, package revision names incorporate package-metadata generation so every installed package gets a new revision on upgrade, and the `type` label on watch metrics changes from `ComposedResource` to `Dependency`. The v1.20 line reaches end-of-life when v2.5 ships in November 2026.
+
+**Source:** [Crossplane v2.4.0 release](https://github.com/crossplane/crossplane/releases/tag/v2.4.0) - August 20, 2026
+
+---
+
+## Kueue 0.19.2 and 0.18.6 fix DRA quota undercounting and a TAS double-assignment bug
+
+Kueue published [v0.19.2](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.2) and the backport [v0.18.6](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.6) on August 20, both carrying scheduling-correctness fixes that matter for GPU fleets. One fixes DRA quota undercounting that occurred when multiple resource names shared the same `deviceClassMappings`, along with mishandled negative extended-resource requests. Another corrects Topology-Aware Scheduling node-replacement logic that could assign two workloads to the same node, plus a domain-matching bug triggered by shared string prefixes.
+
+The releases also add an alpha `TASCacheTopologyTree` feature gate, off by default, that reuses cached topology trees during snapshot creation when scheduling-relevant node data is unchanged, cutting CPU time and allocations. Fair-sharing accounting was fixed to stop entry-penalty leaks that inflated LocalQueue usage.
+
+**Source:** [Kueue v0.19.2 release](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.2) - August 20, 2026
+
+---
+
+## Kubernetes ships an August patch wave across three supported minors
+
+The release team cut [v1.36.4](https://github.com/kubernetes/kubernetes/releases/tag/v1.36.4), v1.35.8, and v1.34.11 on August 20. The v1.36.4 changelog lists a DRA scheduling fix for shared-counter caches, a preemption race condition, a kubelet fix for duplicate CDI device IDs surfaced by DRA drivers, and a bump of `golang.org/x/net` and `golang.org/x/text` to pull in upstream Go security updates.
+
+There is no dedicated Kubernetes CVE in this wave; the security content is the transitive dependency refresh. The DRA-related fixes are the notable ones for operators running dynamic resource allocation drivers for GPUs and other accelerators.
+
+**Source:** [Kubernetes CHANGELOG-1.36 (v1.36.4)](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md) - August 20, 2026
+
+---

--- a/content/news/2026-08-21-wasmtime-sandbox-escape-crossplane-2-4-kueue-tas/index.mdx
+++ b/content/news/2026-08-21-wasmtime-sandbox-escape-crossplane-2-4-kueue-tas/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Wasmtime patches a filesystem sandbox escape, Crossplane 2.4 adds dependency watches, Kueue fixes DRA quota accounting"
-description: "Wasmtime shipped a coordinated patch wave for a high-severity filesystem sandbox escape (CVSS 8.8), Crossplane 2.4.0 lets composition functions watch resources they don't own, and Kueue 0.19.2/0.18.6 corrected DRA quota undercounting for GPU workloads."
+description: "Wasmtime shipped a coordinated patch wave for a high-severity filesystem sandbox escape (CVSS 8.8), Crossplane 2.4.0 lets composition functions watch resources they don't own, Kueue 0.19.2/0.18.6 corrected DRA quota undercounting for GPU workloads, and Kubernetes cut an August patch wave across three supported minors."
 publishedAt: 2026-08-21
 authors:
   - rawkode
@@ -17,7 +17,7 @@ Four primary-source releases in the last 24 hours span WebAssembly sandboxing, p
 
 The Bytecode Alliance published [advisory GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg) on August 20, describing a filesystem sandbox escape rated CVSS 8.8. A guest granted read or write access to a preopened directory through `wasmtime-wasi` could use a trailing slash on a path or symlink to escape the sandbox and reach the host filesystem. The root cause is in the `cap-std` dependency (GHSA-hp8f-xmx4-4qrg), not Wasmtime's own path logic.
 
-The exposure is platform-dependent: hosts on Linux kernels older than 5.6, which lack the `openat2` syscall, and macOS are affected, while newer Linux kernels using the `RESOLVE_BENEATH` resolution flag are not. Fixes shipped the same day as patches to every supported line — [24.0.13](https://github.com/bytecodealliance/wasmtime/releases/tag/v24.0.13), [36.0.14](https://github.com/bytecodealliance/wasmtime/releases/tag/v36.0.14), 46.0.3, and 47.0.4 — alongside the feature release 48.0.0.
+The exposure is platform-dependent: hosts on Linux kernels older than 5.6, which lack the `openat2` syscall, and macOS are affected, while newer Linux kernels using the `RESOLVE_BENEATH` resolution flag are not. Fixes shipped the same day as patches to every supported line — [24.0.13](https://github.com/bytecodealliance/wasmtime/releases/tag/v24.0.13), [36.0.14](https://github.com/bytecodealliance/wasmtime/releases/tag/v36.0.14), [46.0.3](https://github.com/bytecodealliance/wasmtime/releases/tag/v46.0.3), and [47.0.4](https://github.com/bytecodealliance/wasmtime/releases/tag/v47.0.4) — alongside the feature release [48.0.0](https://github.com/bytecodealliance/wasmtime/releases/tag/v48.0.0).
 
 Anyone running untrusted modules with WASI filesystem access on macOS or pre-5.6 kernels should patch rather than rely on the kernel-level mitigation.
 
@@ -47,7 +47,7 @@ The releases also add an alpha `TASCacheTopologyTree` feature gate, off by defau
 
 ## Kubernetes ships an August patch wave across three supported minors
 
-The release team cut [v1.36.4](https://github.com/kubernetes/kubernetes/releases/tag/v1.36.4), v1.35.8, and v1.34.11 on August 20. The v1.36.4 changelog lists a DRA scheduling fix for shared-counter caches, a preemption race condition, a kubelet fix for duplicate CDI device IDs surfaced by DRA drivers, and a bump of `golang.org/x/net` and `golang.org/x/text` to pull in upstream Go security updates.
+The release team cut [v1.36.4](https://github.com/kubernetes/kubernetes/releases/tag/v1.36.4), [v1.35.8](https://github.com/kubernetes/kubernetes/releases/tag/v1.35.8), and [v1.34.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.34.11) on August 20. The v1.36.4 changelog lists a DRA scheduling fix for shared-counter caches, a preemption race condition, a kubelet fix for duplicate CDI device IDs surfaced by DRA drivers, and a bump of `golang.org/x/net` and `golang.org/x/text` to pull in upstream Go security updates.
 
 There is no dedicated Kubernetes CVE in this wave; the security content is the transitive dependency refresh. The DRA-related fixes are the notable ones for operators running dynamic resource allocation drivers for GPUs and other accelerators.
 


### PR DESCRIPTION
## Summary

A four-segment daily digest drawn only from primary sources published in the last 24 hours. The lead item is a high-severity (CVSS 8.8) filesystem sandbox escape in Wasmtime, patched across every supported branch on the same day. The rest cover a Crossplane 2.4.0 feature release with real reconciliation semantics changes, a pair of Kueue backports fixing DRA quota accounting and a TAS double-assignment bug relevant to GPU fleets, and the Kubernetes August patch wave across three supported minors. The spread is deliberately cross-domain (WebAssembly security, platform engineering, batch/GPU scheduling, Kubernetes core) rather than a single-vendor roundup.

## Run metadata

- Run time: `2026-08-21 06:00 Europe/London`
- Coverage window: `2026-08-20 06:00 Europe/London` to `2026-08-21 06:00 Europe/London`
- Source URLs inspected: `~28`
- Candidates longlisted: `12`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- Wasmtime patches a filesystem sandbox escape across four release branches - CVSS 8.8 trailing-slash symlink escape via cap-std; patch or lose the WASI filesystem sandbox on macOS/pre-5.6 kernels.
- Crossplane 2.4.0 lets composition functions watch required resources - dependency changes now trigger immediate reconciliation instead of waiting for the next poll.
- Kueue 0.19.2 and 0.18.6 fix DRA quota undercounting and a TAS double-assignment bug - correctness fixes that directly affect GPU quota and topology placement.
- Kubernetes ships an August patch wave across three supported minors - notable DRA scheduling and CDI device-ID fixes plus transitive Go security bumps.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Wasmtime advisory GHSA-vqjp-4c8c-hfgg, CVSS 8.8, trailing-slash symlink filesystem sandbox escape rooted in cap-std (GHSA-hp8f-xmx4-4qrg) | [GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg) | ✅ |
| Patched in 24.0.13, 36.0.14, 46.0.3, 47.0.4; affects pre-5.6 Linux (no openat2) and macOS; RESOLVE_BENEATH kernels unaffected | [GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg) + [v36.0.14](https://github.com/bytecodealliance/wasmtime/releases/tag/v36.0.14) | ✅ |
| Wasmtime 48.0.0 feature release published same day (Aug 20) | [wasmtime releases.atom](https://github.com/bytecodealliance/wasmtime/releases) | ✅ |
| Crossplane 2.4.0 adds watching of required resources (immediate reconcile), safe-start scale-to-zero, buildGoModule scannable images; CLI moves to cli.crossplane.io | [Crossplane v2.4.0](https://github.com/crossplane/crossplane/releases/tag/v2.4.0) | ✅ |
| Kueue 0.19.2/0.18.6 fix DRA quota undercounting with shared deviceClassMappings, TAS node-replacement double-assignment; add alpha TASCacheTopologyTree gate; published Aug 20 | [Kueue v0.19.2](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.2) / [v0.18.6](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.6) | ✅ |
| Kubernetes v1.36.4/1.35.8/1.34.11 cut Aug 20; v1.36.4 changelog lists DRA shared-counter cache fix, preemption race, duplicate CDI device IDs, x/net + x/text security bumps | [CHANGELOG-1.36](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md) | ✅ |

## Items considered and dropped

- vLLM v0.28.0rc1 (Aug 20) - pre-release release candidate; substance limited to a single `resolve_trust_remote_code` security guard, not an upgrade target. Note for review: the trust-remote-code hardening is worth revisiting when v0.28.0 goes GA.
- Backstage v1.54.1 (Aug 20) - patch release on top of v1.54.0 (Aug 19, outside window); too thin to stand alone.
- Kubernetes v1.37.0-rc.1 (Aug 20) - release candidate; the 1.37 story belongs to GA/sneak-peek coverage, not a daily item.
- CNCF blog posts (Aug 20: "Announcing H1 2027 KCDs", "German ciphers... data sovereignty") - events/positioning, no technical artifact.
- arXiv cs.DC preprints (Aug 20-21: "The Lazy Pod That Lies", "CacheRoute", "FleetSieve", "SLO-Scaler") - relevant systems work, but single unreviewed preprints without a shipped artifact don't clear the news bar.
- Releases confirmed outside the 24h window and excluded: Cilium 1.20.1 (Aug 18), Istio 1.31.0-rc.0 (Aug 19), Argo CD 3.5.1 (Aug 12), Flux 2.9.4 (Aug 7), Prometheus 3.14.0 (Aug 17/18), containerd 2.3.4 (Aug 12), Grafana 13.2.0 (Aug 19), Talos 1.13.9 (Aug 19), Dynamo 1.4.0 (Aug 17), Helm 4.2.4 (Aug 14).

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 12 longlisted (5 shortlisted)
- Segments shipped: 4
- Any unresolved framing concerns: The Kubernetes patch wave has no dedicated project CVE - its security content is transitive Go dependency updates. The segment states this explicitly so it is not read as a critical Kubernetes vulnerability.
- Any vendor-attributed claims: none; all four segments trace to project GitHub releases, changelogs, or security advisories.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJD7Ur6MvXshaSSXbWayQ)_