### PR TITLE
feat(content): align Zitadel Docker Compose title

### DIFF
--- a/content/courses/complete-guide-zitadel/03-install-docker-compose.mdx
+++ b/content/courses/complete-guide-zitadel/03-install-docker-compose.mdx
@@ -2,7 +2,7 @@
 course: "complete-guide-zitadel"
 section: "Getting Started"
 
-title: "Zitadel Docker Compose Local Dev Setup (2026)"
+title: "How to Install Zitadel with Docker Compose (Step-by-Step)"
 slug: "install-docker-compose"
 description: "Run Zitadel locally with Docker Compose and Postgres: health checks, master key, TLS for dev, and the console on localhost:8080."
 


### PR DESCRIPTION
## Summary

- align the Academy course lesson title with the live YouTube title experiment
- keep the lesson slug, description, and body unchanged for clean attribution

## Experiment

- experiment: `RKA-001`
- YouTube video: `GoFGkcwrkPc`
- title applied on 22 August 2026 at 15:00 BST: `How to Install Zitadel with Docker Compose (Step-by-Step)`
- evaluate after at least 42 elapsed days and 60 post-change YouTube Search views

## Verification

- YouTube Studio reported all changes saved
- parsed the MDX YAML frontmatter successfully
- verified exactly one matching title entry
- inspected the scoped Jujutsu diff: one line in one file

## CI

The website check currently fails during `bun install --frozen-lockfile` because the repository lockfile would change. The PR does not modify dependencies or the lockfile; all CodeQL checks pass.