### PR TITLE
fix(content): correct Teleport Linux installation title

### DIFF
--- a/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
+++ b/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
@@ -1,7 +1,7 @@
 ---
 id: pgrokuuhvovem0ajyew4tncu
 slug: part-2-tutorial-installing-teleport
-title: How to Install Teleport on Kubernetes (Step-by-Step)
+title: How to Install Teleport on Linux (APT, YUM and Curl)
 description: >-
   Three ways to install Teleport on Linux: the Debian APT repo, the Red Hat YUM
   repo, and a curl script for other distros. Then start the server, create the

--- a/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
+++ b/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
@@ -1,7 +1,7 @@
 ---
 id: pgrokuuhvovem0ajyew4tncu
 slug: part-2-tutorial-installing-teleport
-title: Part 2. Tutorial -  Installing Teleport
+title: How to Install Teleport on Kubernetes (Step-by-Step)
 description: >-
   Three ways to install Teleport on Linux: the Debian APT repo, the Red Hat YUM
   repo, and a curl script for other distros. Then start the server, create the


### PR DESCRIPTION
## Summary

- align the Academy website title with the corrected live YouTube title
- replace the invalid Kubernetes claim with the video's actual Linux installation scope
- keep all other content unchanged

## Experiment

- experiment: `RKA-007`
- YouTube video: `jGPeOJo2XHc`
- corrected live title: `How to Install Teleport on Linux (APT, YUM and Curl)`
- decision: the previous Kubernetes title failed the factual-correctness guardrail and was rolled back in YouTube Studio
- website action: mirror the publicly verified corrected title

## Authorization

Merge-authorized after required checks pass. Do not bypass a failing required check.