### PR TITLE
Rawkode Academy News - August 27, 2026

### DIFF
--- a/content/news/2026-08-27-kubernetes-1-37-garhwal/index.mdx
+++ b/content/news/2026-08-27-kubernetes-1-37-garhwal/index.mdx
@@ -1,0 +1,47 @@
+---
+title: "Kubernetes v1.37 Garhwal ships gang scheduling to beta and dates the ipvs removal"
+description: "Kubernetes v1.37 lands 67 enhancements, promotes native gang scheduling and DRA device taints to production tiers, and puts the ipvs kube-proxy backend on a fixed removal timeline."
+publishedAt: 2026-08-27
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+Kubernetes cut its third release of 2026 in the last 24 hours, and it dominated the window. Rather than a single "new version" note, here are the three changes in v1.37 that actually alter how platform, batch, and networking teams operate.
+
+## Kubernetes v1.37 Garhwal graduates KYAML, Pod Certificates, and node-declared features to stable
+
+The Kubernetes project released [v1.37, codenamed Garhwal](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/), on August 26 with 67 enhancements: 16 graduating to stable, 23 to beta, and 27 new in alpha.
+
+Among the stable graduations, KYAML (KEP-5295) becomes a supported `kubectl` output format, a flow-style YAML subset that removes the indentation and type-coercion ambiguities that break generated manifests. Pod Certificates ([KEP-4317](https://github.com/kubernetes/enhancements/issues/4317)) reach GA, delivering short-lived X.509 identities to workloads through a `podCertificate` projected volume with no sidecar. Node-declared features ([KEP-5328](https://github.com/kubernetes/enhancements/issues/5328)) also go stable, letting a node advertise its feature-gated capabilities to the control plane so the scheduler and kubelet avoid placing workloads on nodes that cannot honour them during a skewed upgrade.
+
+The 1.37 branch enters maintenance mode in August 2027 and reaches end of life in October 2027.
+
+**Source:** [Kubernetes blog](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/) - August 26, 2026
+
+---
+
+## Native gang scheduling reaches beta with a Workload API and PodGroup
+
+[KEP-4671, Gang Scheduling Support](https://github.com/kubernetes/enhancements/issues/4671), moves to beta in v1.37 after shipping as alpha in 1.35 and 1.36. Owned by SIG Scheduling with the workload-aware-scheduling working group, it adds a Workload API and a decoupled `PodGroup` object that the scheduler treats as an all-or-nothing unit: if the whole group cannot be placed, the scheduler defers instead of partially scheduling it. The beta promotion adds workload scheduling cycles and delayed preemption.
+
+The release also advances Dynamic Resource Allocation for GPU fleets. Device-level taints and tolerations ([KEP-5055](https://github.com/kubernetes/enhancements/issues/5055)) graduate to GA, so a driver can taint a failing accelerator and have the scheduler drain claims off it. A new alpha standard `numaNode` device attribute ([KEP-6072](https://github.com/kubernetes/enhancements/issues/6072)) lets drivers report NUMA locality in a common form, so the scheduler can co-allocate a GPU and a NIC on the same NUMA node.
+
+For teams running training and batch on Kubernetes, in-tree gang scheduling removes the need for an external queueing layer to get all-or-nothing placement, the primitive distributed training jobs can deadlock without.
+
+**Source:** [KEP-4671 gang scheduling](https://github.com/kubernetes/enhancements/issues/4671) - August 26, 2026
+
+---
+
+## kube-proxy warns iptables users and sets a firm ipvs removal date
+
+v1.37 continues the migration off both legacy kube-proxy backends. Under [KEP-5343](https://github.com/kubernetes/enhancements/issues/5343), an unset proxy `mode` still defaults to iptables but now logs a warning, staging the eventual switch to nftables, a backend that has been GA since 1.33.
+
+The ipvs backend gets a concrete end date. [KEP-5495](https://github.com/kubernetes/enhancements/issues/5495) adds a `KubeProxyIPVS` feature gate, enabled by default in 1.37, that is scheduled to flip off in v1.40 and lock in v1.43, at which point ipvs mode is removed. kubeadm now emits a delayed deprecation warning that points ipvs users to nftables on modern kernels or iptables on older ones. Kube-proxy also drops the `nft` command-line tool for list operations in favour of the kernel netlink interface, cutting per-sync overhead.
+
+Operators still running ipvs now have a fixed migration window: the gate defaults off in v1.40 and the backend is removed in v1.43.
+
+**Source:** [KEP-5495 deprecate ipvs mode in kube-proxy](https://github.com/kubernetes/enhancements/issues/5495) - August 26, 2026
+
+---

--- a/content/news/2026-08-27-kubernetes-1-37-garhwal/index.mdx
+++ b/content/news/2026-08-27-kubernetes-1-37-garhwal/index.mdx
@@ -8,7 +8,7 @@ technologies:
   - kubernetes
 ---
 
-Kubernetes cut its third release of 2026 in the last 24 hours, and it dominated the window. Rather than a single "new version" note, here are the three changes in v1.37 that actually alter how platform, batch, and networking teams operate.
+In the last 24 hours Kubernetes cut a new minor release, and it dominated the window. Rather than a single "new version" note, here are the three changes in v1.37 that actually alter how platform, batch, and networking teams operate.
 
 ## Kubernetes v1.37 Garhwal graduates KYAML, Pod Certificates, and node-declared features to stable
 
@@ -28,7 +28,7 @@ The 1.37 branch enters maintenance mode in August 2027 and reaches end of life i
 
 The release also advances Dynamic Resource Allocation for GPU fleets. Device-level taints and tolerations ([KEP-5055](https://github.com/kubernetes/enhancements/issues/5055)) graduate to GA, so a driver can taint a failing accelerator and have the scheduler drain claims off it. A new alpha standard `numaNode` device attribute ([KEP-6072](https://github.com/kubernetes/enhancements/issues/6072)) lets drivers report NUMA locality in a common form, so the scheduler can co-allocate a GPU and a NIC on the same NUMA node.
 
-For teams running training and batch on Kubernetes, in-tree gang scheduling removes the need for an external queueing layer to get all-or-nothing placement, the primitive distributed training jobs can deadlock without.
+For teams running training and batch on Kubernetes, in-tree gang scheduling removes the need for an external queueing layer to get all-or-nothing placement — the primitive that distributed training jobs can deadlock without.
 
 **Source:** [KEP-4671 gang scheduling](https://github.com/kubernetes/enhancements/issues/4671) - August 26, 2026
 
@@ -38,7 +38,7 @@ For teams running training and batch on Kubernetes, in-tree gang scheduling remo
 
 v1.37 continues the migration off both legacy kube-proxy backends. Under [KEP-5343](https://github.com/kubernetes/enhancements/issues/5343), an unset proxy `mode` still defaults to iptables but now logs a warning, staging the eventual switch to nftables, a backend that has been GA since 1.33.
 
-The ipvs backend gets a concrete end date. [KEP-5495](https://github.com/kubernetes/enhancements/issues/5495) adds a `KubeProxyIPVS` feature gate, enabled by default in 1.37, that is scheduled to flip off in v1.40 and lock in v1.43, at which point ipvs mode is removed. kubeadm now emits a delayed deprecation warning that points ipvs users to nftables on modern kernels or iptables on older ones. Kube-proxy also drops the `nft` command-line tool for list operations in favour of the kernel netlink interface, cutting per-sync overhead.
+The ipvs backend gets a concrete end date. [KEP-5495](https://github.com/kubernetes/enhancements/issues/5495) adds a `KubeProxyIPVS` feature gate, on by default in 1.37, that is scheduled to default to off in v1.40 and lock to that default in v1.43, at which point ipvs mode is removed. kubeadm now emits a delayed deprecation warning that points ipvs users to nftables on modern kernels or iptables on older ones. kube-proxy also drops the `nft` command-line tool for list operations in favour of the kernel netlink interface, cutting per-sync overhead.
 
 Operators still running ipvs now have a fixed migration window: the gate defaults off in v1.40 and the backend is removed in v1.43.
 


### PR DESCRIPTION
## Summary

Today's window was dominated by a single primary-source event: the **Kubernetes v1.37 "Garhwal"** release (published 2026-08-26). Rather than a thin "new version shipped" note or padding with stale ecosystem items, this digest breaks the release into the three changes that actually alter how platform, batch/AI, and networking teams operate: the stable graduations that reduce operational surface, native gang scheduling reaching beta (with DRA improvements for GPU fleets), and the kube-proxy nftables/ipvs migration timeline. Discovery surfaced no other in-window (last-24h) primary releases worth shipping, so this is a focused 3-segment issue by design, not by omission.

## Run metadata

- Run time: `2026-08-27 06:00 Europe/London`
- Coverage window: `2026-08-26 06:00 Europe/London` to `2026-08-27 06:00 Europe/London`
- Source URLs inspected: `~30` (web searches + direct fetches of primary sources)
- Candidates longlisted: `~10`
- Candidates shortlisted: `3`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- **Kubernetes v1.37 Garhwal graduates KYAML, Pod Certificates, and node-declared features to stable** — the release overview plus the GA graduations that cut operational surface (sidecar-free workload identity, safer generated manifests, upgrade-skew-aware scheduling).
- **Native gang scheduling reaches beta with a Workload API and PodGroup** — KEP-4671 goes beta; all-or-nothing placement lands in-tree, plus DRA device taints GA and a standard NUMA attribute for GPU/NIC co-allocation.
- **kube-proxy warns iptables users and sets a firm ipvs removal date** — KEP-5343 iptables-default warning and the KEP-5495 ipvs removal schedule (gate off in v1.40, removed in v1.43).

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| v1.37 "Garhwal" released 2026-08-26 | [kubernetes.io blog](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/); [release info page](https://kubernetes.io/releases/1.37/) | ✅ |
| 67 enhancements (16 stable / 23 beta / 27 alpha) | Official release blog + corroborating release coverage | ✅ |
| KYAML (KEP-5295) → stable | [sig-release highlights #3051](https://github.com/kubernetes/sig-release/discussions/3051); corroborated by Palark and Cloudsmith | ✅ |
| Pod Certificates (KEP-4317) → GA, `podCertificate` projected volume | sig-release #3051; Cloudsmith deep-dive | ✅ |
| Node-declared features (KEP-5328) → stable | sig-release #3051 | ✅ |
| Gang Scheduling (KEP-4671) → beta; Workload API + PodGroup, all-or-nothing, delayed preemption | [KEP-4671 enhancement issue](https://github.com/kubernetes/enhancements/issues/4671) | ✅ |
| DRA device-level taints & tolerations (KEP-5055) → GA | [KEP-5055](https://github.com/kubernetes/enhancements/issues/5055); sig-release #3051 | ✅ |
| Standard `numaNode` DRA attribute (KEP-6072) → alpha | [KEP-6072](https://github.com/kubernetes/enhancements/issues/6072); sig-release #3051 | ✅ |
| kube-proxy unset mode defaults to iptables with warning (KEP-5343); nftables GA since 1.33 | [KEP-5343](https://github.com/kubernetes/enhancements/issues/5343); release coverage | ✅ |
| ipvs (KEP-5495): `KubeProxyIPVS` gate default-true in 1.37, off in v1.40, locked/removed v1.43; kubeadm delayed warning; netlink for list ops | [KEP-5495](https://github.com/kubernetes/enhancements/issues/5495) | ✅ |
| 1.37 maintenance mode Aug 2027, EOL Oct 2027 | [release info page](https://kubernetes.io/releases/1.37/) | ✅ |

## Items considered and dropped

- **vLLM / SGLang releases** — most recent verifiable releases were June 2026; nothing in the 24h window. Dropped on freshness.
- **OpenTelemetry / Prometheus releases** — no primary release dated within the window. Dropped on freshness.
- **Gateway API v1.6 / Istio 1.28.9** — real but out of window (June / earlier August). Dropped on freshness.
- **arXiv GPU scheduling / inference papers** — no clearly window-dated primary submission surfaced. Dropped on unverifiable timestamp.
- **cert-manager / SPIRE / sigstore / Argo CD** — no in-window primary release found. Dropped on freshness.
- **Deeper v1.37 alpha wave (pod-level checkpoint/restore, internal API type elimination, nftables localhost NodePort proxy)** — real but lower actionability for the general audience this cycle; held to keep the issue tight rather than padded.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial Review → Fact-check → Edit Pass → Final Review
- Total candidates considered: ~10
- Segments shipped: 3 (meets the 3-segment floor; the window genuinely did not support more without padding)
- Any unresolved framing concerns: none. Sources initially diverged on the gang-scheduling KEP number/stage (some secondary coverage said alpha / different KEP); resolved against the primary sig-release highlights and KEP-4671, which confirm **beta**.
- Any vendor-attributed claims: none. All claims trace to kubernetes.io primary sources and the kubernetes/enhancements KEP tracker.
- Requested labels: `news`, `content`, `needs-review` (apply on merge-triage).
- Branch note: shipped on `claude/beautiml-dijkstra-mluy60` per this session's configured development branch rather than a `news/…` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTp5vvcjLe3ExpfGThjpep)_