### PR TITLE
Rawkode Academy News - September 1, 2026

### DIFF
--- a/content/news/2026-09-01-istio-1-31-flux-2-9-5-k8s-storage-version-migration/index.mdx
+++ b/content/news/2026-09-01-istio-1-31-flux-2-9-5-k8s-storage-version-migration/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "Istio 1.31 ships ambient scalability and FIPS 140-3, Flux returns to upstream Helm, Kubernetes graduates Storage Version Migration"
+description: "Istio cut a stable 1.31.0 with ambient XDS scoping, FIPS 140-3 and zone-aware load balancing, Flux 2.9.5 moved its controllers back to upstream Helm and hardened kubeconfig handling, and Kubernetes v1.37 marked Storage Version Migration GA and on by default."
+publishedAt: 2026-09-01
+authors:
+  - rawkode
+technologies:
+  - istio
+  - flux
+  - kubernetes
+---
+
+Three primary-source items landed inside the last 24 hours: a stable Istio minor, a Flux patch that unwinds a Helm fork, and a Kubernetes v1.37 feature reaching GA. It was an otherwise quiet window, so this is a tight three-item digest rather than a padded one.
+
+## Istio 1.31.0 scopes ambient XDS pushes and adds a FIPS 140-3 compliance policy
+
+Istio published [1.31.0](https://istio.io/latest/news/releases/1.31.x/announcing-1.31/) on August 31, the first stable release of the 1.31 line, concentrating on ambient-mode scalability alongside new security and traffic-management controls.
+
+In ambient mode, istiod now scopes XDS pushes triggered by workload and service address changes to only the affected waypoints rather than pushing broadly, and services can reference primary and canary waypoints with weighted traffic distribution for gradual waypoint rollouts. Security adds a `fips-140-3` value for the `COMPLIANCE_POLICY` environment variable, enforcing TLS 1.2+ with FIPS-compliant cipher suites, plus `trustDomains` and `notTrustDomains` fields on an AuthorizationPolicy `Source` to match requests on the peer certificate's trust domain. Traffic management gains a `zoneAwareLbSetting` field for zone-aware routing with cross-region failover, an `istio-agentgateway-waypoint` `GatewayClass` for running agentgateway as a waypoint, and an `ALLOW_ANY_DYNAMIC_DNS` outbound mode built on Envoy's dynamic forward proxy. The release also fixes multi-cluster memory leaks and a concurrent map write in the CNI agent.
+
+**Source:** [Istio 1.31 release announcement](https://istio.io/latest/news/releases/1.31.x/announcing-1.31/) - August 31, 2026
+
+---
+
+## Flux 2.9.5 moves controllers back to upstream Helm v4.2.4 and rejects file-referencing kubeconfigs
+
+The Flux project released [v2.9.5](https://github.com/fluxcd/flux2/releases/tag/v2.9.5) on August 31, returning helm-controller and source-controller from a temporary Flux-maintained Helm fork to the upstream Helm v4.2.4 dependency.
+
+The release also tightens kubeconfig handling: helm-controller and kustomize-controller now reject kubeconfig Secrets that reference local filesystem paths in the `certificate-authority`, `tokenFile`, `client-certificate`, or `client-key` fields, requiring those credentials to be embedded inline instead. Controller versions in this release are source-controller v1.9.5, helm-controller v1.6.4, kustomize-controller v1.9.5, notification-controller v1.9.4, and the image-reflector and image-automation controllers at v1.2.5. It additionally fixes a panic in post-build variable substitution with negative-length substring expressions.
+
+The kubeconfig change closes a path where a Secret could point a controller at local files on the controller host, so teams driving remote clusters via kubeconfig Secrets should confirm their credentials are inlined before upgrading.
+
+**Source:** [Flux v2.9.5 release](https://github.com/fluxcd/flux2/releases/tag/v2.9.5) - August 31, 2026
+
+---
+
+## Kubernetes v1.37 marks Storage Version Migration GA and enabled by default
+
+Kubernetes published a [v1.37 feature blog](https://kubernetes.io/blog/2026/08/31/kubernetes-v1-37-storage-version-migration-ga/) on August 31 marking Storage Version Migration as generally available and enabled by default. The built-in `StorageVersionMigration` API (`storagemigration.k8s.io/v1`) and its control-plane controller are now stable.
+
+A declarative `StorageVersionMigration` object names a target group and resource, and the built-in StorageVersionMigrator controller rewrites existing objects back through the API server into the current default storage version. That covers two operational cases: safely removing an old API version from a CustomResourceDefinition's `.status.storedVersions` after a version promotion, and re-encrypting data at rest after configuring encryption or rotating keys, since existing objects otherwise keep their old on-disk representation until rewritten. The in-tree path replaces manual `kubectl get`/`kubectl replace` scripts and the out-of-tree kube-storage-version-migrator component.
+
+**Source:** [Kubernetes blog](https://kubernetes.io/blog/2026/08/31/kubernetes-v1-37-storage-version-migration-ga/) - August 31, 2026
+
+---

--- a/content/news/2026-09-01-istio-1-31-flux-2-9-5-k8s-storage-version-migration/index.mdx
+++ b/content/news/2026-09-01-istio-1-31-flux-2-9-5-k8s-storage-version-migration/index.mdx
@@ -6,7 +6,7 @@ authors:
   - rawkode
 technologies:
   - istio
-  - flux
+  - fluxcd
   - kubernetes
 ---
 


### PR DESCRIPTION
## Summary

A tight three-item digest for the 24 hours ending 06:00 Europe/London on 2026-09-01. Discovery swept primary-source release pages, project blogs, CNCF announcements and arXiv; three items had verified in-window timestamps and real technical substance: a stable Istio minor, a Flux patch that unwinds a maintained Helm fork, and a Kubernetes v1.37 feature reaching GA. The window was otherwise quiet, so this ships three rather than padding to a target count.

## Run metadata

- Run time: `2026-09-01 06:00 Europe/London`
- Coverage window: `2026-08-31 06:00 Europe/London` to `2026-09-01 06:00 Europe/London`
- Source URLs inspected: `~34`
- Candidates longlisted: `4`
- Candidates shortlisted: `4`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Istio 1.31.0 - stable minor with ambient XDS-push scoping, weighted waypoint canaries, a FIPS 140-3 compliance policy, AuthorizationPolicy trust-domain matching, and zone-aware load balancing.
- Flux 2.9.5 - moves helm-controller and source-controller back to upstream Helm v4.2.4 and rejects kubeconfig Secrets that reference local filesystem paths.
- Kubernetes v1.37 - Storage Version Migration graduates to GA and is enabled by default, replacing the out-of-tree kube-storage-version-migrator.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Istio 1.31.0 published 2026-08-31 (15:47 UTC) | github.com/istio/istio/releases (release list) | ✅ |
| Ambient XDS pushes scoped to affected waypoints; weighted waypoint canaries | istio.io/latest/news/releases/1.31.x/announcing-1.31/change-notes/ | ✅ |
| `fips-140-3` value for `COMPLIANCE_POLICY`; TLS 1.2+ FIPS ciphers | istio.io 1.31 change-notes, Security & Compliance | ✅ |
| AuthorizationPolicy `trustDomains`/`notTrustDomains` on Source | istio.io 1.31 change-notes | ✅ |
| `zoneAwareLbSetting`, `istio-agentgateway-waypoint` GatewayClass, `ALLOW_ANY_DYNAMIC_DNS` | istio.io 1.31 change-notes, Traffic Management | ✅ |
| Flux v2.9.5 published 2026-08-31 (17:05 UTC) | github.com/fluxcd/flux2/releases/tag/v2.9.5 | ✅ |
| Controllers move back to upstream Helm v4.2.4 | flux2 v2.9.5 release notes | ✅ |
| kubeconfig Secrets rejecting local-file references in CA/tokenFile/client-cert/client-key | flux2 v2.9.5 release notes (security hardening) | ✅ |
| Controller versions (source 1.9.5, helm 1.6.4, kustomize 1.9.5, notification 1.9.4, image-* 1.2.5) | flux2 v2.9.5 release notes | ✅ |
| SVM GA + enabled by default; API `storagemigration.k8s.io/v1` | kubernetes.io/blog/2026/08/31/kubernetes-v1-37-storage-version-migration-ga/ | ✅ |
| Use cases: dropping old CRD storedVersions; re-encrypting at rest; replaces kube-storage-version-migrator | same blog post | ✅ |

## Items considered and dropped

- Helm v4.3.0-rc.1 / v3.22.0-rc.1 (2026-08-31) - release candidates with no published changelog yet ("official changelog will come out with the v4.3.0 release"); no verifiable technical substance to report.
- CNCF "OpenTelemetry has graduated… now what?" maintainer post (2026-08-31) - retrospective/opinion, not a release or governance event; this pipeline ships news, not takes.
- arXiv cs.DC submissions (LLM inference / HPC scheduling, 2026-08-31/09-01) - fresh but timestamps and titles could not be reliably corroborated via primary fetch; papers are borderline for a daily news digest without a clear operational hook.
- Kubernetes v1.37 "Pod Certificates and Cluster Trust Bundles" (2026-08-28) and "Metrics API GA" (2026-08-27) blogs - outside the 24-hour window.
- No in-window releases from Kubernetes core, Cilium, Prometheus, vLLM, Argo CD, Kueue, etcd, containerd, OpenTelemetry Collector, Grafana, SGLang, cert-manager, Envoy, Crossplane, KubeVirt, Gateway API, cosign, Karpenter, NCCL, KEDA, Kyverno, Talos, CRI-O, Ray, or TensorRT-LLM.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 4 in-window; ~34 source URLs inspected
- Segments shipped: 3
- Framing note on the Kubernetes item: v1.37.0 itself shipped 2026-08-26 (outside the window); the fresh primary artifact is the Storage Version Migration GA feature blog dated 2026-08-31, which is what the segment cites.
- One Istio claim (a move of release artifact hosting off `gcr.io/istio-release`) appeared in one summary but was **not** corroborated by the change-notes page, so it was deliberately omitted from the segment.
- Any vendor-attributed claims: none - all three items trace to primary project sources (Istio release announcement, Flux release notes, Kubernetes blog).

---
_Generated by [Claude Code](https://claude.ai/code/session_012xAxsAxgCfgeJ8GBYjNBF2)_