### PR TITLE
Rawkode Academy News - September 3, 2026

### DIFF
--- a/content/news/2026-09-03-cloud-native-ai-infra-digest/index.mdx
+++ b/content/news/2026-09-03-cloud-native-ai-infra-digest/index.mdx
@@ -1,0 +1,55 @@
+---
+title: "Cloud Native and AI Infrastructure Digest: September 3, 2026"
+description: "PyTorch 2.14 lands an nccl2 distributed backend and c10d fault tolerance, the OpenTelemetry Collector consolidates keepalive config, Kubernetes 1.37 promotes HPA scale-to-zero to beta, and SeaweedFS discloses an unpatched weed iam privilege escalation."
+publishedAt: 2026-09-03
+authors:
+  - rawkode
+---
+
+### PyTorch 2.14 ships an nccl2 distributed backend and moves fault tolerance into c10d
+
+PyTorch 2.14 shipped on September 2 with changes aimed squarely at large-scale distributed training.
+
+The release adds `nccl2`, a backend ported from torchcomms that implements the full collective contract with nonblocking communicators and eager communicator splitting, opt-in via `TORCH_DIST_USE_NCCL2=1`. Fault tolerance becomes a first-class `c10d` concept, with in-place process-group reconfiguration, one-sided RMA windows, and a Flight Recorder that works across any backend rather than only NCCL. On the compiler side, NVGEMM brings CuTeDSL-generated CUTLASS kernels — including scaled and NVFP4 GEMM — into Inductor, which now also targets NVIDIA Rubin (`sm_107`), and ROCm 7.14 wheels are produced from the TheRock SDK.
+
+Moving reconfiguration and a backend-agnostic Flight Recorder into `c10d` turns fleet recovery from a framework-level workaround into a supported primitive.
+
+**Source:** [PyTorch](https://github.com/pytorch/pytorch/releases/tag/v2.14.0) - September 2, 2026
+
+---
+
+### OpenTelemetry Collector 1.66 consolidates HTTP keepalive config and drops Go 1.25
+
+The OpenTelemetry Collector released v1.66.0/v0.160.0 on September 2, with a config deprecation and a toolchain bump to schedule around.
+
+`confighttp` deprecates the flat keepalive fields — `idle_conn_timeout`, `max_idle_conns`, `max_idle_conns_per_host`, `idle_timeout`, and the `disable_keep_alives`/`keep_alives_enabled` toggles — in favour of a consolidated `keepalive` section; existing configurations still load but emit deprecation warnings. The minimum Go version moves to 1.26.0, dropping 1.25.0. A batching change in `exporterhelper` now caches request size per sizer type, removing the O(n²) recomputation that appeared under `sizer: bytes` accumulation. The paired contrib distribution shipped the same day.
+
+Operators using byte-sized batching get the performance fix without touching config, but the keepalive rename needs a migration before the flat fields are eventually removed.
+
+**Source:** [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.160.0) - September 2, 2026
+
+---
+
+### Kubernetes 1.37 promotes HPA scale-to-zero to beta and enables it by default
+
+A September 2 Kubernetes blog post details HorizontalPodAutoscaler scale-to-zero graduating to beta in v1.37, on by default after shipping as alpha.
+
+An HPA can now scale a target workload down to zero replicas when it is driven by object or external metrics — a signal such as queue length that exists independently of running Pods, unlike CPU or memory metrics that need a live Pod to measure. It requires a metrics adapter such as the Prometheus Adapter, and workloads must tolerate cold start: the HPA has to observe the metric, schedule a Pod, and let the application start before it can serve traffic. Kubernetes Services do not buffer requests while no Pods are ready, so request-driven workloads still need a buffering layer in front.
+
+Event- and queue-driven workloads that previously reached zero only through KEDA or a custom controller can now do so with core HPA, provided they scale on object or external metrics.
+
+**Source:** [Kubernetes](https://kubernetes.io/blog/2026/09/02/kubernetes-v1-37-hpa-scale-to-zero-beta/) - September 2, 2026
+
+---
+
+### SeaweedFS discloses an unpatched privilege escalation in the standalone weed iam server
+
+SeaweedFS published a critical security advisory on September 2 for its standalone `weed iam` server, with no fixed release available yet.
+
+In the deprecated-but-still-distributed `weed iam` server, every IAM action routes through a single `POST /` endpoint that calls `VerifyActionPermission` with empty bucket and object parameters. The evaluator resolves those to the ARN `arn:aws:s3:::` and action `s3:*`, so any identity holding a standard broad S3 data policy (`s3:*` on `*`) is wrongly granted full IAM administration — enough to mint access keys for other accounts, attach admin policies to itself, or delete other users' credentials. Versions up to and including 4.40 are affected and the advisory lists no patched version. The embedded IAM path (`weed s3 -iam=true`) is unaffected because it namespaces actions under an `iam:` prefix that `s3:*` policies cannot match.
+
+Operators running the standalone IAM server cannot patch their way out yet, so mitigation means retiring that server or tightly constraining who holds broad S3 policies until a fix ships.
+
+**Source:** [SeaweedFS](https://github.com/seaweedfs/seaweedfs/security/advisories/GHSA-jw56-gm6j-34mp) - September 2, 2026
+
+---

--- a/content/news/2026-09-03-cloud-native-ai-infra-digest/index.mdx
+++ b/content/news/2026-09-03-cloud-native-ai-infra-digest/index.mdx
@@ -4,6 +4,10 @@ description: "PyTorch 2.14 lands an nccl2 distributed backend and c10d fault tol
 publishedAt: 2026-09-03
 authors:
   - rawkode
+technologies:
+  - opentelemetry
+  - kubernetes
+  - seaweedfs
 ---
 
 ### PyTorch 2.14 ships an nccl2 distributed backend and moves fault tolerance into c10d


### PR DESCRIPTION
## Summary

Four fresh, verified segments from the last 24 hours, spanning training frameworks, observability, Kubernetes core, and supply-chain security. Each traces to a Tier 1 primary source (GitHub release, official project blog, or the project's own security advisory) published within the coverage window. Weaker, stale, or experimental-only items were cut rather than padded — see "Items considered and dropped."

## Run metadata

- Run time: `2026-09-03 06:15 Europe/London`
- Coverage window: `2026-09-02 06:00` to `2026-09-03 06:00` (Europe/London)
- Source URLs inspected: `~50`
- Candidates longlisted: `~15`
- Candidates shortlisted: `6`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- PyTorch 2.14 nccl2 backend and c10d fault tolerance - moves distributed reconfiguration and a backend-agnostic Flight Recorder from framework workaround into a supported primitive
- OpenTelemetry Collector 1.66.0/0.160.0 - deprecates flat HTTP keepalive fields for a consolidated section, bumps min Go to 1.26.0, and fixes O(n²) byte-sized batching
- Kubernetes 1.37 HPA scale-to-zero to beta - core HPA can now scale object/external-metric workloads to zero replicas by default, reducing reliance on KEDA for that case
- SeaweedFS unpatched `weed iam` privilege escalation - a broad `s3:*` data policy is wrongly granted full IAM admin on the standalone server; no fix released yet

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| PyTorch 2.14 released 2026-09-02 with `nccl2` backend, first-class `c10d` fault tolerance + cross-backend Flight Recorder, NVGEMM/CuTeDSL NVFP4 GEMM in Inductor, Rubin `sm_107`, ROCm 7.14 | [GitHub release v2.14.0](https://github.com/pytorch/pytorch/releases/tag/v2.14.0) + [release blog](https://pytorch.org/blog/pytorch-2-14-release-blog/) ("Last updated: 2026-09-02") | ✅ |
| OTel Collector v1.66.0/v0.160.0 released 2026-09-02 14:38 UTC; `confighttp` keepalive fields deprecated for `keepalive` section; min Go 1.26.0 (drops 1.25.0); `exporterhelper` caches request size per sizer | [GitHub release v0.160.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.160.0) + releases.atom `<updated>` | ✅ |
| Kubernetes 1.37 promotes HPA scale-to-zero to beta, on by default; object/external metrics only; needs metrics adapter; Services do not buffer requests at zero | [Kubernetes blog, 2026-09-02](https://kubernetes.io/blog/2026/09/02/kubernetes-v1-37-hpa-scale-to-zero-beta/) (byline Sep 02, 2026) | ✅ |
| SeaweedFS GHSA-jw56-gm6j-34mp, Critical, published 2026-09-02; standalone `weed iam` `POST /` calls `VerifyActionPermission` with empty params → `s3:*` policy grants full IAM admin; affected ≤ 4.40; no patched version; `weed s3 -iam=true` unaffected | [GitHub Security Advisory](https://github.com/seaweedfs/seaweedfs/security/advisories/GHSA-jw56-gm6j-34mp) | ✅ (date; see reviewer notes on exact hour) |

## Items considered and dropped

- NVIDIA Dynamo `v1.5.0-inkling-dev.1` / `v1.5.0-gemma-4-31b-dev.1` - in-window but experimental dev pre-releases, not production; low signal
- vLLM `v0.29.0rc1` (2026-09-02 02:11 UTC) - release candidate and published before the 06:00 window start
- Dapr `v1.18.4-rc.3`, k3s `v1.37.0-rc1/rc2`, Backstage `v1.55.0-next.1`, Helm `v4.3.0-rc.1` - prereleases, low signal
- arXiv 2609.02514 (AceSpec edge-cloud LLM inference), 2609.02238 (APPFL federated learning) - in-window papers but weaker fit / lower actionability than the shipped four
- CNCF "Metal3 meets KubeVirtBMC" blog - Tier 2 community post, day-granular timestamp only
- GitHub Advisory DB batch dated "Sep 2" (OpenChoreo, older SeaweedFS CVEs, `hurl`, etc.) - aggregator import dates; canonical disclosures predate the window (verified July 2026 publish dates)
- Kratix rolling `latest` tag re-point - CI re-tag, not a versioned release

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~15
- Segments shipped: 4
- **SeaweedFS advisory freshness:** the advisory page shows a "Published September 2, 2026" date but not an exact clock time. The window starts 06:00 UTC on Sep 2, so a pre-06:00 publish cannot be fully ruled out from the page alone. Included on the strength of the confirmed Sep 2 date plus its repo-only state (not yet mirrored to the global GitHub Advisory Database — the `/advisories/GHSA-jw56-gm6j-34mp` path 404s), which is consistent with a very recent publish. It is also high-value: Critical severity, no CVE assigned yet, and no patched release available.
- **Environment note:** the GitHub REST API was unavailable this run (scoped to this repo), so all external timestamps were verified via each project's `releases.atom`/`feed.xml` rather than the API. WebFetch's HTML prose parser intermittently misreported years (rendering 2026 as 2024); load-bearing dates were cross-checked against structured atom/feed timestamps.
- Any vendor-attributed claims: none — no unverified vendor benchmark numbers are carried in the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wec7V1zipNztsw3rm4J17H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wec7V1zipNztsw3rm4J17H)_