### PR TITLE
Rawkode Academy News - September 5, 2026

### DIFF
--- a/content/news/2026-09-05-sglang-containerd-kubernetes-talos/index.mdx
+++ b/content/news/2026-09-05-sglang-containerd-kubernetes-talos/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "SGLang 0.5.19 ships beam search, containerd patches an unpack DoS, Kubernetes 1.37 rootless goes beta"
+description: "SGLang cut a large 0.5.19 release with beam search and DeepEP v2, containerd shipped coordinated security patches across every supported branch, and Kubernetes promoted rootless node components to beta."
+publishedAt: 2026-09-05
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - containerd
+---
+
+Four primary-source items landed in the last 24 hours across AI inference serving, container-runtime security, and Kubernetes node hardening. The window skewed toward security, so most of this digest is upgrade-driven.
+
+## SGLang 0.5.19 adds beam search and DeepEP v2 for MoE serving
+
+The SGLang project published [v0.5.19](https://github.com/sgl-project/sglang/releases/tag/v0.5.19) on September 5, rolling up 786 pull requests from 214 contributors, more than 50 of them new.
+
+The release adds beam search: callers pass `beam_width` in a request and get back the n best sequences. Mixture-of-experts serving moves to DeepEP v2 with an ElasticBuffer engine, and LayerNorm sequence parallelism cuts reported prefill time by 3.5 to 5.6 percent. There is W4A8 MoE quantization on Hopper GPUs and a lean attention kernel for AMD MI355X that the project reports at up to 1.52x throughput. Several changes are breaking: the unified radix tree is now the default across configurations, `ServerArgs` no longer auto-resolves values, FlashInfer 0.6.18 is required, and requests are capped at 32 stop strings or regex patterns of 256 bytes each.
+
+Teams pinning SGLang images should read the breaking-change list before the next bump; the default radix-tree switch and `ServerArgs` change alter runtime behaviour without an opt-in.
+
+**Source:** [SGLang v0.5.19 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.19) - September 5, 2026
+
+---
+
+## containerd patches an unpack DoS and tightens descriptor-URL credential handling
+
+containerd shipped coordinated patch releases on September 4 across every supported branch: [2.3.5](https://github.com/containerd/containerd/releases/tag/v2.3.5), 2.2.8, 2.0.12, and 1.7.35.
+
+The headline fix is [GHSA-rp3h-jf77-q9p4](https://github.com/containerd/containerd/security/advisories/GHSA-rp3h-jf77-q9p4), a moderate-severity unpack denial of service with no assigned CVE. A crafted image using repeated opaque whiteouts forces superlinear-time directory traversals during layer unpacking, inflating CPU and unpack time; on shared nodes that delays container start and can cut image-pull concurrency for unrelated workloads. Affected versions are below 1.7.35, below 2.0.12, 2.2.0 through 2.2.7, and 2.3.0 through 2.3.4. Separately, the docker fetcher now normalizes descriptor-URL origins and strips sensitive authentication headers when fetching descriptor URLs, so registry credentials no longer leak to third-party hosts referenced in an image manifest; the release notes track this as CVE-2026-53495.
+
+Because the DoS affects any node that pulls untrusted images, this is a fleet-wide upgrade rather than a single-branch backport.
+
+**Source:** [containerd v2.3.5 release](https://github.com/containerd/containerd/releases/tag/v2.3.5) - September 4, 2026
+
+---
+
+## Kubernetes 1.37 promotes rootless node components to beta
+
+The Kubernetes blog announced on September 4 that the [`KubeletInUserNamespace` feature gate](https://kubernetes.io/blog/2026/09/04/kubernetes-v1-37-rootless-beta/) graduates to beta in v1.37.
+
+With the gate enabled, all node components — the kubelet, the CRI and OCI runtimes, CNI plugins, and kube-proxy — run as a non-root user on the host inside a Linux user namespace, so a container breakout is confined to an unprivileged account rather than host root. The capability first merged as alpha in v1.22 in 2021. It is distinct from pod-level user namespaces (`hostUsers: false`), which isolate pods while node components still run as root; the two compose for running Kubernetes nested inside a pod.
+
+**Source:** [Kubernetes blog](https://kubernetes.io/blog/2026/09/04/kubernetes-v1-37-rootless-beta/) - September 4, 2026
+
+---
+
+## Talos 1.12.12 hardens kubelet certificate handling
+
+Sidero Labs released [Talos v1.12.12](https://github.com/siderolabs/talos/releases/tag/v1.12.12) on September 4 with 13 commits.
+
+The patch hardens the code around the kubelet's client-certificate handling, filters passed metadata during API proxying, and adds validation for meta keys in API paths. It also fixes tar-archive extraction to create parent directories and preserve special file modes, and escapes dashboard output. The node image ships Linux 6.18.49, containerd 2.2.7, Kubernetes 1.35.8, etcd 3.6.14, and Go 1.25.14.
+
+**Source:** [Talos v1.12.12 release](https://github.com/siderolabs/talos/releases/tag/v1.12.12) - September 4, 2026
+
+---

--- a/content/news/2026-09-05-sglang-containerd-kubernetes-talos/index.mdx
+++ b/content/news/2026-09-05-sglang-containerd-kubernetes-talos/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "SGLang 0.5.19 ships beam search, containerd patches an unpack DoS, Kubernetes 1.37 rootless goes beta"
-description: "SGLang cut a large 0.5.19 release with beam search and DeepEP v2, containerd shipped coordinated security patches across every supported branch, and Kubernetes promoted rootless node components to beta."
+title: "SGLang 0.5.19, a containerd security patch wave, Kubernetes 1.37 rootless beta, and Talos 1.12.12"
+description: "SGLang cut a large 0.5.19 release with beam search and DeepEP v2, containerd shipped coordinated security patches across every supported branch, Kubernetes promoted rootless node components to beta, and Talos 1.12.12 hardened kubelet certificate handling."
 publishedAt: 2026-09-05
 authors:
   - rawkode


### PR DESCRIPTION
## Summary

A security-heavy 24-hour window. This digest ships four verified, in-window items: a large SGLang inference-server release (beam search, DeepEP v2 MoE serving, new quantization and attention kernels), a coordinated containerd patch wave fixing a moderate unpack denial of service plus descriptor-URL credential hardening across every supported branch, the beta graduation of rootless Kubernetes node components in v1.37, and a Talos patch that hardens kubelet certificate handling. vLLM (release candidates only), Talos v1.14.0, Kueue, and Gateway API were considered but fell outside the strict 24-hour window or lacked a stable artifact.

## Run metadata

- Run time: `2026-09-05 06:00 Europe/London`
- Coverage window: `2026-09-04 05:00 UTC` to `2026-09-05 05:00 UTC` (24h, BST)
- Source URLs inspected: `~34`
- Candidates longlisted: `12`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- SGLang 0.5.19 adds beam search and DeepEP v2 for MoE serving - large release (786 PRs) with runtime-behaviour-changing defaults teams must plan around.
- containerd patches an unpack DoS and tightens descriptor-URL credential handling - fleet-wide security upgrade affecting any node pulling untrusted images.
- Kubernetes 1.37 promotes rootless node components to beta - node components can now run as non-root via user namespaces, confining container breakouts.
- Talos 1.12.12 hardens kubelet certificate handling - control-plane hardening plus tar-extraction and API-proxy metadata fixes.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| SGLang v0.5.19 published Sep 5, 2026 (02:27 UTC), 786 PRs / 214 contributors | github.com/sgl-project/sglang releases.atom + release tag v0.5.19 | ✅ |
| SGLang adds beam search, DeepEP v2/ElasticBuffer, LayerNorm SP 3.5–5.6% prefill, W4A8 MoE on Hopper, MI355X lean attention up to 1.52x | SGLang v0.5.19 release notes | ✅ |
| SGLang breaking changes: default unified radix tree, FlashInfer 0.6.18, ServerArgs no auto-resolve, 32 stop strings/regex @256B | SGLang v0.5.19 release notes | ✅ |
| containerd 2.3.5/2.2.8/2.0.12/1.7.35 released Sep 4, 2026 | github.com/containerd/containerd releases.atom + v2.3.5 tag | ✅ |
| GHSA-rp3h-jf77-q9p4 "Unpack DoS via repeated opaque whiteouts", Moderate, no CVE; affected/patched versions | github.com/containerd/containerd security advisory GHSA-rp3h-jf77-q9p4 | ✅ |
| Auth-header stripping on descriptor-URL fetches, tracked as CVE-2026-53495 | containerd v2.3.5 release notes security bullet | ✅ |
| KubeletInUserNamespace graduates to beta in v1.37; kubelet/CRI/OCI/CNI/kube-proxy run rootless via user namespaces; alpha since v1.22 | kubernetes.io/blog/2026/09/04/kubernetes-v1-37-rootless-beta | ✅ |
| Talos v1.12.12 released Sep 4, 2026, 13 commits; kubelet cert hardening, API metadata filtering, tar-extraction fix; component versions | github.com/siderolabs/talos releases.atom + v1.12.12 tag | ✅ |

## Items considered and dropped

- vLLM v0.29.0rc3/rc4 (Sep 4) - release candidates only; no stable v0.29.0 exists yet (404), individually low substance.
- Kueue v0.19.3 / v0.18.7 (Sep 3) - out of window; DRA device-class mapping fix was notable but predates the 24h window.
- Gateway API v1.6.2 (Sep 3) - out of window; minor conformance-classification patch.
- Talos v1.14.0 (Sep 3) - out of window despite being the larger release (sandboxd, native BGP, multi-doc config).
- OTel Collector Contrib v0.160.0 (Sep 2), Grafana 13.2.1 wave (Sep 2), NCCL4Py v0.5.0 (Sep 1) - out of window.
- ai-dynamo dev snapshots (Sep 3–4) - experimental/dev builds explicitly not recommended for production.
- Wasmtime v49.0.0-rc.1 (Sep 5) - release candidate, low individual substance.
- CNCF "Kubernetes isn't new, but AI makes it scary again" (Sep 4) - commentary blog, no technical artifact.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 12
- Segments shipped: 4
- Any unresolved framing concerns: containerd release notes reference CVE-2026-53495 for the descriptor-URL auth-header hardening, but no standalone published GitHub advisory page for that ID was found at run time; the segment attributes it to the release notes rather than asserting an advisory. The unpack DoS (GHSA-rp3h-jf77-q9p4) is fully documented.
- Any vendor-attributed claims: SGLang's MI355X "up to 1.52x throughput" is written as project-reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRxRCSG5HFYVLc1f9tLsNh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRxRCSG5HFYVLc1f9tLsNh)_